### PR TITLE
Returning to simpler way of skipping husky

### DIFF
--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,6 +1,0 @@
-// Skip Husky install in production and CI
-if (process.env.NODE_ENV === 'production' || process.env.CI === 'true') {
-	process.exit(0)
-  }
-  const husky = (await import('husky')).default
-  console.log(husky())

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:22-alpine
 WORKDIR /app
 
 # Copy the package.json and package-lock.json files
-COPY package*.json ./ .husky/
+COPY package*.json ./ 
 
 # Install the dependencies
 RUN npm install

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "prepare": "node .husky/install.mjs"
+    "prepare": "husky || true"
   },
   "author": "MCFD Mobility",
   "license": "MIT License",


### PR DESCRIPTION
Skips husky using an or statement. This does not error out the build, tested locally with docker.