### PR TITLE
Feat/reflect url params

### DIFF
--- a/src/common/constants/parameter-constants.ts
+++ b/src/common/constants/parameter-constants.ts
@@ -4,5 +4,6 @@ const CONTENT_TYPE = 'application/json';
 const PAGINATION = 'N';
 
 const idRegex = /[0-9\-A-Za-z]+/;
+const idName = 'rowId';
 
-export { VIEW_MODE, CHILD_LINKS, CONTENT_TYPE, PAGINATION, idRegex };
+export { VIEW_MODE, CHILD_LINKS, CONTENT_TYPE, PAGINATION, idRegex, idName };

--- a/src/common/constants/upstream-constants.ts
+++ b/src/common/constants/upstream-constants.ts
@@ -1,9 +1,11 @@
 const baseUrlEnvVarName = 'UPSTREAM_BASE_URL';
 const supportNetworkEndpointEnvVarName = 'SUPPORT_NETWORK_ENDPOINT';
 const inPersonVisitsEndpointEnvVarName = 'IN_PERSON_VISITS_ENDPOINT';
+const idirUsernameHeaderField = 'x-idir-username';
 
 export {
   baseUrlEnvVarName,
   supportNetworkEndpointEnvVarName,
   inPersonVisitsEndpointEnvVarName,
+  idirUsernameHeaderField,
 };

--- a/src/common/guards/auth/auth.guard.spec.ts
+++ b/src/common/guards/auth/auth.guard.spec.ts
@@ -78,6 +78,9 @@ describe('AuthGuard', () => {
         switchToHttp: () => ({
           getRequest: () => getMockReq(),
         }),
+        getClass: () => {
+          return TestController;
+        },
       };
       const isAuthed = await guard.canActivate(execContext as ExecutionContext);
       expect(authSpy).toHaveBeenCalledTimes(0);
@@ -123,6 +126,9 @@ describe('AuthGuard', () => {
         switchToHttp: () => ({
           getRequest: () => getMockReq(),
         }),
+        getClass: () => {
+          return TestController;
+        },
       };
       const isAuthed = await guard.canActivate(execContext);
       expect(authSpy).toHaveBeenCalledTimes(1);

--- a/src/common/guards/auth/auth.guard.ts
+++ b/src/common/guards/auth/auth.guard.ts
@@ -18,6 +18,8 @@ export class AuthGuard implements CanActivate {
       return true;
     }
     const request = context.switchToHttp().getRequest();
-    return await this.authService.getRecordAndValidate(request);
+    const controllerPath =
+      Reflect.getMetadata('path', context.getClass()) || '';
+    return await this.authService.getRecordAndValidate(request, controllerPath);
   }
 }

--- a/src/common/guards/auth/auth.service.spec.ts
+++ b/src/common/guards/auth/auth.service.spec.ts
@@ -29,8 +29,6 @@ describe('AuthService', () => {
   const validRecordType = RecordType.Case;
   const validPath = `/${validRecordType}/${validId}/testendpoint`;
   const notinEnumPath = `/fjofijp/${validId}/testendpoint`;
-  const noIdPath = `/${validRecordType}`;
-  const incorrectFormatPath = 'abcdefg';
   const testIdir = 'IDIRTEST';
 
   beforeEach(async () => {
@@ -142,28 +140,32 @@ describe('AuthService', () => {
     );
   });
 
-  describe('grabRecordInfoFromPath tests', () => {
+  describe('grabRecordInfo tests', () => {
     it('returns an array of [id, type] when the correct url format is passed', () => {
-      const [id, recordType] = service.grabRecordInfoFromPath(validPath);
+      const mockRequest = getMockReq({
+        params: { [idName]: validId },
+      });
+      const [id, recordType] = service.grabRecordInfo(
+        mockRequest,
+        validRecordType,
+      );
       expect(id).toEqual(validId);
       expect(recordType).toEqual(validRecordType);
     });
 
     it(`throws an error when the enum doesn't match the record type`, () => {
+      const mockRequest = getMockReq({
+        params: { [idName]: validId },
+      });
       expect(() => {
-        service.grabRecordInfoFromPath(notinEnumPath);
+        service.grabRecordInfo(mockRequest, notinEnumPath);
       }).toThrow(EnumTypeError);
     });
 
-    it(`throws an error when the url doesn't match the correct format`, () => {
+    it(`throws an error when the parameter doesn't exist for id`, () => {
+      const mockRequest = getMockReq();
       expect(() => {
-        service.grabRecordInfoFromPath(incorrectFormatPath);
-      }).toThrow(Error);
-    });
-
-    it(`throws an error when the url doen't have an id`, () => {
-      expect(() => {
-        service.grabRecordInfoFromPath(noIdPath);
+        service.grabRecordInfo(mockRequest, validRecordType);
       }).toThrow(Error);
     });
   });

--- a/src/common/guards/auth/auth.service.spec.ts
+++ b/src/common/guards/auth/auth.service.spec.ts
@@ -27,8 +27,7 @@ describe('AuthService', () => {
 
   const validId = 'id1234';
   const validRecordType = RecordType.Case;
-  const validPath = `/${validRecordType}/${validId}/testendpoint`;
-  const notinEnumPath = `/fjofijp/${validId}/testendpoint`;
+  const notinEnumPath = `fjofijp`;
   const testIdir = 'IDIRTEST';
 
   beforeEach(async () => {
@@ -93,7 +92,6 @@ describe('AuthService', () => {
         } as AxiosResponse<any, any>),
       );
       const mockRequest = getMockReq({
-        path: validPath,
         header: jest.fn((key: string): string => {
           const headerVal: { [key: string]: string } = {
             [idirUsernameHeaderField]: testIdir,
@@ -102,10 +100,9 @@ describe('AuthService', () => {
         }),
         params: { [idName]: 'id' },
       });
-      const controllerPath = 'case';
       const isAuthed = await service.getRecordAndValidate(
         mockRequest,
-        controllerPath,
+        validRecordType,
       );
       expect(spy).toHaveBeenCalledTimes(1);
       expect(cacheSpy).toHaveBeenCalledTimes(2);
@@ -122,17 +119,15 @@ describe('AuthService', () => {
           .spyOn(cache, 'get')
           .mockResolvedValueOnce(cacheReturn);
         const mockRequest = getMockReq({
-          path: validPath,
           header: jest.fn((key: string): string => {
             const headerVal: { [key: string]: string } = headers;
             return headerVal[key];
           }),
           params: { [idName]: 'id' },
         });
-        const controllerPath = 'case';
         const isAuthed = await service.getRecordAndValidate(
           mockRequest,
-          controllerPath,
+          validRecordType,
         );
         expect(cacheSpy).toHaveBeenCalledTimes(cacheSpyCallTimes);
         expect(isAuthed).toBe(false);
@@ -163,7 +158,7 @@ describe('AuthService', () => {
     });
 
     it(`throws an error when the parameter doesn't exist for id`, () => {
-      const mockRequest = getMockReq();
+      const mockRequest = getMockReq({ params: {} });
       expect(() => {
         service.grabRecordInfo(mockRequest, validRecordType);
       }).toThrow(Error);

--- a/src/common/guards/auth/auth.service.spec.ts
+++ b/src/common/guards/auth/auth.service.spec.ts
@@ -16,6 +16,8 @@ import { RecordType } from '../../../common/constants/enumerations';
 import { EnumTypeError } from '../../../common/errors/errors';
 import { UtilitiesService } from '../../../helpers/utilities/utilities.service';
 import { TokenRefresherService } from '../../../external-api/token-refresher/token-refresher.service';
+import { idirUsernameHeaderField } from '../../../common/constants/upstream-constants';
+import { idName } from '../../../common/constants/parameter-constants';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -96,12 +98,17 @@ describe('AuthService', () => {
         path: validPath,
         header: jest.fn((key: string): string => {
           const headerVal: { [key: string]: string } = {
-            'x-idir-username': testIdir,
+            [idirUsernameHeaderField]: testIdir,
           };
           return headerVal[key];
         }),
+        params: { [idName]: 'id' },
       });
-      const isAuthed = await service.getRecordAndValidate(mockRequest);
+      const controllerPath = 'case';
+      const isAuthed = await service.getRecordAndValidate(
+        mockRequest,
+        controllerPath,
+      );
       expect(spy).toHaveBeenCalledTimes(1);
       expect(cacheSpy).toHaveBeenCalledTimes(2);
       expect(isAuthed).toBe(true);
@@ -109,7 +116,7 @@ describe('AuthService', () => {
 
     it.each([
       [{}, undefined, 0],
-      [{ 'x-idir-username': testIdir }, null, 1],
+      [{ [idirUsernameHeaderField]: testIdir }, null, 1],
     ])(
       'should return false with invalid record',
       async (headers, cacheReturn, cacheSpyCallTimes) => {
@@ -122,8 +129,13 @@ describe('AuthService', () => {
             const headerVal: { [key: string]: string } = headers;
             return headerVal[key];
           }),
+          params: { [idName]: 'id' },
         });
-        const isAuthed = await service.getRecordAndValidate(mockRequest);
+        const controllerPath = 'case';
+        const isAuthed = await service.getRecordAndValidate(
+          mockRequest,
+          controllerPath,
+        );
         expect(cacheSpy).toHaveBeenCalledTimes(cacheSpyCallTimes);
         expect(isAuthed).toBe(false);
       },

--- a/src/common/guards/auth/auth.service.ts
+++ b/src/common/guards/auth/auth.service.ts
@@ -66,17 +66,6 @@ export class AuthService {
     return true;
   }
 
-  grabRecordInfoFromPath(path: string): [string, RecordType] {
-    const pathParts = path.trim().slice(1).split('/', 2); // slice removes the leading / in the url
-    if (!this.utilitiesService.enumTypeGuard(RecordType, pathParts[0].trim())) {
-      throw new EnumTypeError(pathParts[0]);
-    }
-    if (pathParts.length < 2) {
-      throw new Error(`Id not found in path: '${path}'`);
-    }
-    return [pathParts[1].trim(), pathParts[0].trim() as RecordType];
-  }
-
   grabRecordInfo(req: Request, controllerPath: string): [string, RecordType] {
     if (!this.utilitiesService.enumTypeGuard(RecordType, controllerPath)) {
       throw new EnumTypeError(controllerPath);

--- a/src/common/guards/auth/auth.service.ts
+++ b/src/common/guards/auth/auth.service.ts
@@ -10,12 +10,16 @@ import { UtilitiesService } from '../../../helpers/utilities/utilities.service';
 import {
   CHILD_LINKS,
   CONTENT_TYPE,
+  idName,
   VIEW_MODE,
 } from '../../../common/constants/parameter-constants';
 import { firstValueFrom } from 'rxjs';
 import { AxiosError } from 'axios';
 import { TokenRefresherService } from '../../../external-api/token-refresher/token-refresher.service';
-import { baseUrlEnvVarName } from '../../../common/constants/upstream-constants';
+import {
+  baseUrlEnvVarName,
+  idirUsernameHeaderField,
+} from '../../../common/constants/upstream-constants';
 
 @Injectable()
 export class AuthService {
@@ -36,11 +40,14 @@ export class AuthService {
     this.buildNumber = this.configService.get<string>('buildInfo.buildNumber');
   }
 
-  async getRecordAndValidate(req: Request): Promise<boolean> {
+  async getRecordAndValidate(
+    req: Request,
+    controllerPath: string,
+  ): Promise<boolean> {
     let idir: string, id: string, recordType: RecordType;
     try {
-      idir = req.header('x-idir-username').trim();
-      [id, recordType] = this.grabRecordInfoFromPath(req.path);
+      idir = req.header(idirUsernameHeaderField).trim();
+      [id, recordType] = this.grabRecordInfo(req, controllerPath);
     } catch (error: any) {
       this.logger.error({ error });
       return false;
@@ -68,6 +75,17 @@ export class AuthService {
       throw new Error(`Id not found in path: '${path}'`);
     }
     return [pathParts[1].trim(), pathParts[0].trim() as RecordType];
+  }
+
+  grabRecordInfo(req: Request, controllerPath: string): [string, RecordType] {
+    if (!this.utilitiesService.enumTypeGuard(RecordType, controllerPath)) {
+      throw new EnumTypeError(controllerPath);
+    }
+    const rowId = req.params[idName];
+    if (rowId === undefined) {
+      throw new Error(`Id not found in path`);
+    }
+    return [rowId, controllerPath as RecordType];
   }
 
   async getAssignedIdirUpstream(

--- a/src/controllers/cases/cases.controller.spec.ts
+++ b/src/controllers/cases/cases.controller.spec.ts
@@ -20,6 +20,7 @@ import {
   InPersonVisitsEntity,
   InPersonVisitsSingleResponseCaseExample,
 } from '../../entities/in-person-visits.entity';
+import { idName } from '../../common/constants/parameter-constants';
 
 describe('CasesController', () => {
   let controller: CasesController;
@@ -55,7 +56,7 @@ describe('CasesController', () => {
     it.each([
       [
         SupportNetworkSingleResponseCaseExample,
-        { id: 'test' } as IdPathParams,
+        { [idName]: 'test' } as IdPathParams,
         { since: '2020-02-02' } as SinceQueryParams,
       ],
     ])(
@@ -83,7 +84,7 @@ describe('CasesController', () => {
     it.each([
       [
         InPersonVisitsSingleResponseCaseExample,
-        { id: 'test' } as IdPathParams,
+        { [idName]: 'test' } as IdPathParams,
         { since: '2020-02-02' } as SinceQueryParams,
       ],
     ])(

--- a/src/controllers/cases/cases.controller.ts
+++ b/src/controllers/cases/cases.controller.ts
@@ -27,7 +27,10 @@ import {
 import { IdPathParams } from '../../dto/id-path-params.dto';
 import { SinceQueryParams } from '../../dto/since-query-params.dto';
 import { ApiNotFoundEntity } from '../../entities/api-not-found.entity';
-import { CONTENT_TYPE } from '../../common/constants/parameter-constants';
+import {
+  CONTENT_TYPE,
+  idName,
+} from '../../common/constants/parameter-constants';
 import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
 import { AuthGuard } from '../../common/guards/auth/auth.guard';
 import {
@@ -45,7 +48,7 @@ export class CasesController {
   constructor(private readonly casesService: CasesService) {}
 
   @UseInterceptors(ClassSerializerInterceptor)
-  @Get(':id/support-network')
+  @Get(`:${idName}/support-network`)
   @ApiOperation({
     description:
       'Find all Support Network entries related to a given Case entity by Case id.',
@@ -98,7 +101,7 @@ export class CasesController {
   }
 
   @UseInterceptors(ClassSerializerInterceptor)
-  @Get(':id/visits')
+  @Get(`:${idName}/visits`)
   @ApiOperation({
     description:
       'Find all In Person Child / Youth Visits related to a given Case entity by Case id.',

--- a/src/controllers/cases/cases.service.spec.ts
+++ b/src/controllers/cases/cases.service.spec.ts
@@ -19,6 +19,7 @@ import {
   InPersonVisitsEntity,
   InPersonVisitsSingleResponseCaseExample,
 } from '../../entities/in-person-visits.entity';
+import { idName } from '../../common/constants/parameter-constants';
 
 describe('CasesService', () => {
   let service: CasesService;
@@ -62,7 +63,7 @@ describe('CasesService', () => {
     it.each([
       [
         SupportNetworkSingleResponseCaseExample,
-        { id: 'test' } as IdPathParams,
+        { [idName]: 'test' } as IdPathParams,
         { since: '2024-12-01' } as SinceQueryParams,
       ],
     ])(
@@ -94,7 +95,7 @@ describe('CasesService', () => {
     it.each([
       [
         InPersonVisitsSingleResponseCaseExample,
-        { id: 'test' } as IdPathParams,
+        { [idName]: 'test' } as IdPathParams,
         { since: '2024-12-01' } as SinceQueryParams,
       ],
     ])(

--- a/src/controllers/incidents/incidents.controller.spec.ts
+++ b/src/controllers/incidents/incidents.controller.spec.ts
@@ -15,6 +15,7 @@ import { SupportNetworkService } from '../../helpers/support-network/support-net
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
+import { idName } from '../../common/constants/parameter-constants';
 
 describe('IncidentsController', () => {
   let controller: IncidentsController;
@@ -49,7 +50,7 @@ describe('IncidentsController', () => {
     it.each([
       [
         SupportNetworkSingleResponseIncidentExample,
-        { id: 'test' } as IdPathParams,
+        { [idName]: 'test' } as IdPathParams,
         { since: '2020-02-02' } as SinceQueryParams,
       ],
     ])(

--- a/src/controllers/incidents/incidents.controller.ts
+++ b/src/controllers/incidents/incidents.controller.ts
@@ -28,7 +28,10 @@ import {
 import { IdPathParams } from '../../dto/id-path-params.dto';
 import { SinceQueryParams } from '../../dto/since-query-params.dto';
 import { ApiNotFoundEntity } from '../../entities/api-not-found.entity';
-import { CONTENT_TYPE } from '../../common/constants/parameter-constants';
+import {
+  CONTENT_TYPE,
+  idName,
+} from '../../common/constants/parameter-constants';
 import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
 import { AuthGuard } from '../../common/guards/auth/auth.guard';
 
@@ -40,7 +43,7 @@ export class IncidentsController {
   constructor(private readonly incidentsService: IncidentsService) {}
 
   @UseInterceptors(ClassSerializerInterceptor)
-  @Get(':id/support-network')
+  @Get(`:${idName}/support-network`)
   @ApiOperation({
     description:
       'Find all Support Network entries related to a given Incident entity by Incident id.',

--- a/src/controllers/incidents/incidents.service.spec.ts
+++ b/src/controllers/incidents/incidents.service.spec.ts
@@ -14,6 +14,7 @@ import { IdPathParams } from '../../dto/id-path-params.dto';
 import { RecordType } from '../../common/constants/enumerations';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
+import { idName } from '../../common/constants/parameter-constants';
 
 describe('IncidentsService', () => {
   let service: IncidentsService;
@@ -52,7 +53,7 @@ describe('IncidentsService', () => {
     it.each([
       [
         SupportNetworkSingleResponseIncidentExample,
-        { id: 'test' } as IdPathParams,
+        { [idName]: 'test' } as IdPathParams,
         { since: '2024-12-01' } as SinceQueryParams,
       ],
     ])(

--- a/src/controllers/service-requests/service-requests.controller.spec.ts
+++ b/src/controllers/service-requests/service-requests.controller.spec.ts
@@ -14,6 +14,7 @@ import { SupportNetworkService } from '../../helpers/support-network/support-net
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
+import { idName } from '../../common/constants/parameter-constants';
 
 describe('ServiceRequestsController', () => {
   let controller: ServiceRequestsController;
@@ -51,7 +52,7 @@ describe('ServiceRequestsController', () => {
     it.each([
       [
         SupportNetworkSingleResponseSRExample,
-        { id: 'test' } as IdPathParams,
+        { [idName]: 'test' } as IdPathParams,
         { since: '2020-02-02' } as SinceQueryParams,
       ],
     ])(

--- a/src/controllers/service-requests/service-requests.controller.ts
+++ b/src/controllers/service-requests/service-requests.controller.ts
@@ -26,7 +26,10 @@ import {
 import { IdPathParams } from '../../dto/id-path-params.dto';
 import { SinceQueryParams } from '../../dto/since-query-params.dto';
 import { ApiNotFoundEntity } from '../../entities/api-not-found.entity';
-import { CONTENT_TYPE } from '../../common/constants/parameter-constants';
+import {
+  CONTENT_TYPE,
+  idName,
+} from '../../common/constants/parameter-constants';
 import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
 
 @Controller('sr')
@@ -36,7 +39,7 @@ export class ServiceRequestsController {
   constructor(private readonly serviceRequestService: ServiceRequestsService) {}
 
   @UseInterceptors(ClassSerializerInterceptor)
-  @Get(':id/support-network')
+  @Get(`:${idName}/support-network`)
   @ApiOperation({
     description:
       'Find all Support Network entries related to a given Service Request entity by Service Request id.',

--- a/src/controllers/service-requests/service-requests.service.spec.ts
+++ b/src/controllers/service-requests/service-requests.service.spec.ts
@@ -14,6 +14,7 @@ import { IdPathParams } from '../../dto/id-path-params.dto';
 import { SinceQueryParams } from '../../dto/since-query-params.dto';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
+import { idName } from '../../common/constants/parameter-constants';
 
 describe('ServiceRequestsService', () => {
   let service: ServiceRequestsService;
@@ -53,7 +54,7 @@ describe('ServiceRequestsService', () => {
     it.each([
       [
         SupportNetworkSingleResponseSRExample,
-        { id: 'test' } as IdPathParams,
+        { [idName]: 'test' } as IdPathParams,
         { since: '2024-12-01' } as SinceQueryParams,
       ],
     ])(

--- a/src/dto/id-path-params.dto.ts
+++ b/src/dto/id-path-params.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Matches } from 'class-validator';
-import { idRegex } from '../common/constants/parameter-constants';
+import { idName, idRegex } from '../common/constants/parameter-constants';
 
 export class IdPathParams {
   @Matches(idRegex)
@@ -8,5 +8,5 @@ export class IdPathParams {
     example: 'Entity-Id-Here',
     description: 'The Entity Id for your selected record type',
   })
-  id: string;
+  [idName]: string;
 }

--- a/src/helpers/in-person-visits/in-person-visits.service.spec.ts
+++ b/src/helpers/in-person-visits/in-person-visits.service.spec.ts
@@ -16,6 +16,7 @@ import {
   InPersonVisitsSingleResponseCaseExample,
   NestedInPersonVisitsEntity,
 } from '../../entities/in-person-visits.entity';
+import { idName } from '../../common/constants/parameter-constants';
 
 describe('InPersonVisitsService', () => {
   let service: InPersonVisitsService;
@@ -56,13 +57,13 @@ describe('InPersonVisitsService', () => {
       [
         InPersonVisitsSingleResponseCaseExample,
         RecordType.Case,
-        { id: 'test' } as IdPathParams,
+        { [idName]: 'test' } as IdPathParams,
         undefined,
       ],
       [
         InPersonVisitsListResponseCaseExample.items[0],
         RecordType.Case,
-        { id: 'test' } as IdPathParams,
+        { [idName]: 'test' } as IdPathParams,
         { since: '2024-12-24' } as SinceQueryParams,
       ],
     ])(
@@ -91,7 +92,7 @@ describe('InPersonVisitsService', () => {
       [
         InPersonVisitsListResponseCaseExample,
         RecordType.Case,
-        { id: 'test' } as IdPathParams,
+        { [idName]: 'test' } as IdPathParams,
         undefined,
       ],
     ])(

--- a/src/helpers/in-person-visits/in-person-visits.service.ts
+++ b/src/helpers/in-person-visits/in-person-visits.service.ts
@@ -12,6 +12,7 @@ import {
   baseUrlEnvVarName,
   inPersonVisitsEndpointEnvVarName,
 } from '../../common/constants/upstream-constants';
+import { idName } from '../../common/constants/parameter-constants';
 
 @Injectable()
 export class InPersonVisitsService {
@@ -37,7 +38,7 @@ export class InPersonVisitsService {
     id: IdPathParams,
     since?: SinceQueryParams,
   ): Promise<InPersonVisitsEntity | NestedInPersonVisitsEntity> {
-    const baseSearchSpec = `([Parent Id]="${id.id}"`;
+    const baseSearchSpec = `([Parent Id]="${id[idName]}"`;
     const [headers, params] =
       this.requestPreparerService.prepareHeadersAndParams(
         baseSearchSpec,

--- a/src/helpers/support-network/support-network.service.spec.ts
+++ b/src/helpers/support-network/support-network.service.spec.ts
@@ -17,6 +17,7 @@ import { IdPathParams } from '../../dto/id-path-params.dto';
 import { SinceQueryParams } from '../../dto/since-query-params.dto';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
+import { idName } from '../../common/constants/parameter-constants';
 
 describe('SupportNetworkService', () => {
   let service: SupportNetworkService;
@@ -57,13 +58,13 @@ describe('SupportNetworkService', () => {
       [
         SupportNetworkSingleResponseCaseExample,
         RecordType.Case,
-        { id: 'test' } as IdPathParams,
+        { [idName]: 'test' } as IdPathParams,
         undefined,
       ],
       [
         SupportNetworkListResponseSRExample.items[0],
         RecordType.SR,
-        { id: 'test' } as IdPathParams,
+        { [idName]: 'test' } as IdPathParams,
         { since: '2024-12-24' } as SinceQueryParams,
       ],
     ])(
@@ -92,7 +93,7 @@ describe('SupportNetworkService', () => {
       [
         SupportNetworkListResponseIncidentExample,
         RecordType.Incident,
-        { id: 'test' } as IdPathParams,
+        { [idName]: 'test' } as IdPathParams,
         undefined,
       ],
     ])(

--- a/src/helpers/support-network/support-network.service.ts
+++ b/src/helpers/support-network/support-network.service.ts
@@ -15,6 +15,7 @@ import {
   baseUrlEnvVarName,
   supportNetworkEndpointEnvVarName,
 } from '../../common/constants/upstream-constants';
+import { idName } from '../../common/constants/parameter-constants';
 
 @Injectable()
 export class SupportNetworkService {
@@ -40,7 +41,7 @@ export class SupportNetworkService {
     id: IdPathParams,
     since?: SinceQueryParams,
   ) {
-    const baseSearchSpec = `([Entity Id]="${id.id}" AND [Entity Name]="${RecordEntityMap[type]}"`;
+    const baseSearchSpec = `([Entity Id]="${id[idName]}" AND [Entity Name]="${RecordEntityMap[type]}"`;
     const [headers, params] =
       this.requestPreparerService.prepareHeadersAndParams(
         baseSearchSpec,


### PR DESCRIPTION
[Story link](https://bcsocialsector.service-now.com/now/nav/ui/classic/params/target/rm_story.do%3Fsys_id%3D21581f7b93e59e50e09fb1584dba1051)

This PR grabs the record type from the controller's path parameter using reflection, and the rowId from the request parameters object, reducing dependence on path structure. id was renamed to rowId, and the name of this parameter was moved into a constant.