### PR TITLE
GET list of attachments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,5 @@ CASE_ENDPOINT=/endpoint/path/here
 INCIDENT_ENDPOINT=/endpoint/path/here
 SR_ENDPOINT=/endpoint/path/here
 MEMO_ENDPOINT=/endpoint/path/here
+ATTACHMENTS_ENDPOINT=/endpoint/path/here
 SKIP_AUTH_GUARD=false

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -87,6 +87,11 @@ spec:
                 secretKeyRef:
                     name: visitz-api
                     key: IN_PERSON_VISITS_ENDPOINT
+            - name: ATTACHMENTS_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                    name: visitz-api
+                    key: ATTACHMENTS_ENDPOINT
             - name: VPI_APP_LABEL
               value: {{ .Values.vpiAppBuildLabel.version }}
       restartPolicy: Always

--- a/src/common/constants/parameter-constants.ts
+++ b/src/common/constants/parameter-constants.ts
@@ -6,6 +6,7 @@ const PAGINATION = 'N';
 const idRegex = /[0-9\-A-Za-z]+/;
 const idName = 'rowId';
 
+const casesAttachmentsFieldName = 'No Intervention';
 const incidentsAttachmentsFieldName = 'Incident No';
 const srAttachmentsFieldName = 'Application No';
 const memoAttachmentsFieldName = 'MemoNumber';
@@ -17,6 +18,7 @@ export {
   PAGINATION,
   idRegex,
   idName,
+  casesAttachmentsFieldName,
   incidentsAttachmentsFieldName,
   srAttachmentsFieldName,
   memoAttachmentsFieldName,

--- a/src/common/constants/parameter-constants.ts
+++ b/src/common/constants/parameter-constants.ts
@@ -6,4 +6,16 @@ const PAGINATION = 'N';
 const idRegex = /[0-9\-A-Za-z]+/;
 const idName = 'rowId';
 
-export { VIEW_MODE, CHILD_LINKS, CONTENT_TYPE, PAGINATION, idRegex, idName };
+const srAttachmentsFieldName = 'Application No';
+const memoAttachmentsFieldName = 'MemoNumber';
+
+export {
+  VIEW_MODE,
+  CHILD_LINKS,
+  CONTENT_TYPE,
+  PAGINATION,
+  idRegex,
+  idName,
+  srAttachmentsFieldName,
+  memoAttachmentsFieldName,
+};

--- a/src/common/constants/parameter-constants.ts
+++ b/src/common/constants/parameter-constants.ts
@@ -6,6 +6,7 @@ const PAGINATION = 'N';
 const idRegex = /[0-9\-A-Za-z]+/;
 const idName = 'rowId';
 
+const incidentsAttachmentsFieldName = 'Incident No';
 const srAttachmentsFieldName = 'Application No';
 const memoAttachmentsFieldName = 'MemoNumber';
 
@@ -16,6 +17,7 @@ export {
   PAGINATION,
   idRegex,
   idName,
+  incidentsAttachmentsFieldName,
   srAttachmentsFieldName,
   memoAttachmentsFieldName,
 };

--- a/src/common/constants/upstream-constants.ts
+++ b/src/common/constants/upstream-constants.ts
@@ -1,11 +1,13 @@
 const baseUrlEnvVarName = 'UPSTREAM_BASE_URL';
 const supportNetworkEndpointEnvVarName = 'SUPPORT_NETWORK_ENDPOINT';
 const inPersonVisitsEndpointEnvVarName = 'IN_PERSON_VISITS_ENDPOINT';
+const attachmentsEndpointEnvVarName = 'ATTACHMENTS_ENDPOINT';
 const idirUsernameHeaderField = 'x-idir-username';
 
 export {
   baseUrlEnvVarName,
   supportNetworkEndpointEnvVarName,
   inPersonVisitsEndpointEnvVarName,
+  attachmentsEndpointEnvVarName,
   idirUsernameHeaderField,
 };

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -30,10 +30,12 @@ export default () => ({
   workspaces: {
     supportNetwork: undefined,
     inPersonVisits: undefined,
+    attachments: 'int_lab',
   },
   sinceFieldName: {
     supportNetwork: 'Updated',
     inPersonVisits: undefined,
+    attachments: undefined,
   },
   skipAuthGuard: process.env.SKIP_AUTH_GUARD === 'true',
   buildInfo: {

--- a/src/controllers/cases/cases.controller.spec.ts
+++ b/src/controllers/cases/cases.controller.spec.ts
@@ -21,6 +21,7 @@ import {
   InPersonVisitsSingleResponseCaseExample,
 } from '../../entities/in-person-visits.entity';
 import { idName } from '../../common/constants/parameter-constants';
+import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 
 describe('CasesController', () => {
   let controller: CasesController;
@@ -33,6 +34,7 @@ describe('CasesController', () => {
         CasesService,
         AuthService,
         SupportNetworkService,
+        AttachmentsService,
         TokenRefresherService,
         InPersonVisitsService,
         RequestPreparerService,

--- a/src/controllers/cases/cases.controller.spec.ts
+++ b/src/controllers/cases/cases.controller.spec.ts
@@ -22,6 +22,10 @@ import {
 } from '../../entities/in-person-visits.entity';
 import { idName } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
+import {
+  AttachmentsSingleResponseCaseExample,
+  AttachmentsEntity,
+} from '../../entities/attachments.entity';
 
 describe('CasesController', () => {
   let controller: CasesController;
@@ -105,6 +109,33 @@ describe('CasesController', () => {
           sinceQueryParams,
         );
         expect(result).toEqual(new InPersonVisitsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleCaseAttachmentRecord tests', () => {
+    it.each([
+      [
+        AttachmentsSingleResponseCaseExample,
+        { [idName]: 'test' } as IdPathParams,
+        { since: '2020-02-02' } as SinceQueryParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams, sinceQueryParams) => {
+        const caseServiceSpy = jest
+          .spyOn(casesService, 'getSingleCaseAttachmentRecord')
+          .mockReturnValueOnce(Promise.resolve(new AttachmentsEntity(data)));
+
+        const result = await controller.getSingleCaseAttachmentRecord(
+          idPathParams,
+          sinceQueryParams,
+        );
+        expect(caseServiceSpy).toHaveBeenCalledWith(
+          idPathParams,
+          sinceQueryParams,
+        );
+        expect(result).toEqual(new AttachmentsEntity(data));
       },
     );
   });

--- a/src/controllers/cases/cases.controller.ts
+++ b/src/controllers/cases/cases.controller.ts
@@ -39,6 +39,12 @@ import {
   InPersonVisitsSingleResponseCaseExample,
   NestedInPersonVisitsEntity,
 } from '../../entities/in-person-visits.entity';
+import {
+  AttachmentsEntity,
+  AttachmentsListResponseCaseExample,
+  AttachmentsSingleResponseCaseExample,
+  NestedAttachmentsEntity,
+} from '../../entities/attachments.entity';
 
 @Controller('case')
 @UseGuards(AuthGuard)
@@ -148,5 +154,55 @@ export class CasesController {
     since?: SinceQueryParams,
   ): Promise<InPersonVisitsEntity | NestedInPersonVisitsEntity> {
     return await this.casesService.getSingleCaseInPersonVisitRecord(id, since);
+  }
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Get(`:${idName}/attachments`)
+  @ApiOperation({
+    description:
+      'Find all Attachments metadata entries related to a given Case entity by Case id.',
+  })
+  @ApiQuery({ name: 'since', required: false })
+  @ApiExtraModels(AttachmentsEntity, NestedAttachmentsEntity)
+  @ApiOkResponse({
+    content: {
+      [CONTENT_TYPE]: {
+        schema: {
+          oneOf: [
+            { $ref: getSchemaPath(AttachmentsEntity) },
+            { $ref: getSchemaPath(NestedAttachmentsEntity) },
+          ],
+        },
+        examples: {
+          AttachmentsSingleResponse: {
+            value: AttachmentsSingleResponseCaseExample,
+          },
+          AttachmentsListResponse: {
+            value: AttachmentsListResponseCaseExample,
+          },
+        },
+      },
+    },
+  })
+  async getSingleCaseAttachmentRecord(
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: IdPathParams,
+    @Query(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+        skipMissingProperties: true,
+      }),
+    )
+    since?: SinceQueryParams,
+  ): Promise<AttachmentsEntity | NestedAttachmentsEntity> {
+    return await this.casesService.getSingleCaseAttachmentRecord(id, since);
   }
 }

--- a/src/controllers/cases/cases.service.spec.ts
+++ b/src/controllers/cases/cases.service.spec.ts
@@ -20,6 +20,7 @@ import {
   InPersonVisitsSingleResponseCaseExample,
 } from '../../entities/in-person-visits.entity';
 import { idName } from '../../common/constants/parameter-constants';
+import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 
 describe('CasesService', () => {
   let service: CasesService;
@@ -32,6 +33,7 @@ describe('CasesService', () => {
       providers: [
         CasesService,
         SupportNetworkService,
+        AttachmentsService,
         UtilitiesService,
         TokenRefresherService,
         InPersonVisitsService,

--- a/src/controllers/cases/cases.service.spec.ts
+++ b/src/controllers/cases/cases.service.spec.ts
@@ -19,13 +19,21 @@ import {
   InPersonVisitsEntity,
   InPersonVisitsSingleResponseCaseExample,
 } from '../../entities/in-person-visits.entity';
-import { idName } from '../../common/constants/parameter-constants';
+import {
+  casesAttachmentsFieldName,
+  idName,
+} from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
+import {
+  AttachmentsSingleResponseCaseExample,
+  AttachmentsEntity,
+} from '../../entities/attachments.entity';
 
 describe('CasesService', () => {
   let service: CasesService;
   let supportNetworkService: SupportNetworkService;
   let inPersonVisitsService: InPersonVisitsService;
+  let attachmentsService: AttachmentsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -55,6 +63,7 @@ describe('CasesService', () => {
     inPersonVisitsService = module.get<InPersonVisitsService>(
       InPersonVisitsService,
     );
+    attachmentsService = module.get<AttachmentsService>(AttachmentsService);
   });
 
   it('should be defined', () => {
@@ -117,6 +126,36 @@ describe('CasesService', () => {
           sinceQueryParams,
         );
         expect(result).toEqual(new InPersonVisitsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleCaseAttachmentRecord tests', () => {
+    it.each([
+      [
+        AttachmentsSingleResponseCaseExample,
+        { [idName]: 'test' } as IdPathParams,
+        { since: '2024-12-01' } as SinceQueryParams,
+        casesAttachmentsFieldName,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams, sinceQueryParams, typeFieldName) => {
+        const attachmentsSpy = jest
+          .spyOn(attachmentsService, 'getSingleAttachmentRecord')
+          .mockReturnValueOnce(Promise.resolve(new AttachmentsEntity(data)));
+
+        const result = await service.getSingleCaseAttachmentRecord(
+          idPathParams,
+          sinceQueryParams,
+        );
+        expect(attachmentsSpy).toHaveBeenCalledWith(
+          RecordType.Case,
+          idPathParams,
+          typeFieldName,
+          sinceQueryParams,
+        );
+        expect(result).toEqual(new AttachmentsEntity(data));
       },
     );
   });

--- a/src/controllers/cases/cases.service.ts
+++ b/src/controllers/cases/cases.service.ts
@@ -12,12 +12,19 @@ import {
   InPersonVisitsEntity,
   NestedInPersonVisitsEntity,
 } from '../../entities/in-person-visits.entity';
+import { AttachmentsService } from '../../helpers/attachments/attachments.service';
+import {
+  AttachmentsEntity,
+  NestedAttachmentsEntity,
+} from '../../entities/attachments.entity';
+import { casesAttachmentsFieldName } from '../../common/constants/parameter-constants';
 
 @Injectable()
 export class CasesService {
   constructor(
     private readonly supportNetworkService: SupportNetworkService,
     private readonly inPersonVisitsService: InPersonVisitsService,
+    private readonly attachmentsService: AttachmentsService,
   ) {}
 
   async getSingleCaseSupportNetworkInformationRecord(
@@ -38,6 +45,18 @@ export class CasesService {
     return await this.inPersonVisitsService.getSingleInPersonVisitRecord(
       RecordType.Case,
       id,
+      since,
+    );
+  }
+
+  async getSingleCaseAttachmentRecord(
+    id: IdPathParams,
+    since?: SinceQueryParams,
+  ): Promise<AttachmentsEntity | NestedAttachmentsEntity> {
+    return await this.attachmentsService.getSingleAttachmentRecord(
+      RecordType.Case,
+      id,
+      casesAttachmentsFieldName,
       since,
     );
   }

--- a/src/controllers/controllers.module.ts
+++ b/src/controllers/controllers.module.ts
@@ -2,8 +2,9 @@ import { Module } from '@nestjs/common';
 import { CasesModule } from './cases/cases.module';
 import { IncidentsModule } from './incidents/incidents.module';
 import { ServiceRequestsModule } from './service-requests/service-requests.module';
+import { MemosModule } from './memos/memos.module';
 
 @Module({
-  imports: [CasesModule, IncidentsModule, ServiceRequestsModule],
+  imports: [CasesModule, IncidentsModule, ServiceRequestsModule, MemosModule],
 })
 export class ControllersModule {}

--- a/src/controllers/incidents/incidents.controller.spec.ts
+++ b/src/controllers/incidents/incidents.controller.spec.ts
@@ -16,6 +16,7 @@ import { TokenRefresherService } from '../../external-api/token-refresher/token-
 import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import { idName } from '../../common/constants/parameter-constants';
+import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 
 describe('IncidentsController', () => {
   let controller: IncidentsController;
@@ -27,6 +28,7 @@ describe('IncidentsController', () => {
       providers: [
         IncidentsService,
         SupportNetworkService,
+        AttachmentsService,
         AuthService,
         TokenRefresherService,
         RequestPreparerService,

--- a/src/controllers/incidents/incidents.controller.spec.ts
+++ b/src/controllers/incidents/incidents.controller.spec.ts
@@ -17,6 +17,10 @@ import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import { idName } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
+import {
+  AttachmentsSingleResponseIncidentExample,
+  AttachmentsEntity,
+} from '../../entities/attachments.entity';
 
 describe('IncidentsController', () => {
   let controller: IncidentsController;
@@ -75,6 +79,33 @@ describe('IncidentsController', () => {
           sinceQueryParams,
         );
         expect(result).toEqual(new SupportNetworkEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleIncidentAttachmentRecord tests', () => {
+    it.each([
+      [
+        AttachmentsSingleResponseIncidentExample,
+        { [idName]: 'test' } as IdPathParams,
+        { since: '2020-02-02' } as SinceQueryParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams, sinceQueryParams) => {
+        const incidentServiceSpy = jest
+          .spyOn(incidentsService, 'getSingleIncidentAttachmentRecord')
+          .mockReturnValueOnce(Promise.resolve(new AttachmentsEntity(data)));
+
+        const result = await controller.getSingleIncidentAttachmentRecord(
+          idPathParams,
+          sinceQueryParams,
+        );
+        expect(incidentServiceSpy).toHaveBeenCalledWith(
+          idPathParams,
+          sinceQueryParams,
+        );
+        expect(result).toEqual(new AttachmentsEntity(data));
       },
     );
   });

--- a/src/controllers/incidents/incidents.controller.ts
+++ b/src/controllers/incidents/incidents.controller.ts
@@ -34,6 +34,12 @@ import {
 } from '../../common/constants/parameter-constants';
 import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
 import { AuthGuard } from '../../common/guards/auth/auth.guard';
+import {
+  AttachmentsEntity,
+  NestedAttachmentsEntity,
+  AttachmentsSingleResponseIncidentExample,
+  AttachmentsListResponseIncidentExample,
+} from '../../entities/attachments.entity';
 
 @Controller('incident')
 @UseGuards(AuthGuard)
@@ -90,6 +96,59 @@ export class IncidentsController {
     since?: SinceQueryParams,
   ): Promise<SupportNetworkEntity | NestedSupportNetworkEntity> {
     return await this.incidentsService.getSingleIncidentSupportNetworkInformationRecord(
+      id,
+      since,
+    );
+  }
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Get(`:${idName}/attachments`)
+  @ApiOperation({
+    description:
+      'Find all Attachments metadata entries related to a given Incident entity by Incident id.',
+  })
+  @ApiQuery({ name: 'since', required: false })
+  @ApiExtraModels(AttachmentsEntity, NestedAttachmentsEntity)
+  @ApiOkResponse({
+    content: {
+      [CONTENT_TYPE]: {
+        schema: {
+          oneOf: [
+            { $ref: getSchemaPath(AttachmentsEntity) },
+            { $ref: getSchemaPath(NestedAttachmentsEntity) },
+          ],
+        },
+        examples: {
+          AttachmentsSingleResponse: {
+            value: AttachmentsSingleResponseIncidentExample,
+          },
+          AttachmentsListResponse: {
+            value: AttachmentsListResponseIncidentExample,
+          },
+        },
+      },
+    },
+  })
+  async getSingleIncidentAttachmentRecord(
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: IdPathParams,
+    @Query(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+        skipMissingProperties: true,
+      }),
+    )
+    since?: SinceQueryParams,
+  ): Promise<AttachmentsEntity | NestedAttachmentsEntity> {
+    return await this.incidentsService.getSingleIncidentAttachmentRecord(
       id,
       since,
     );

--- a/src/controllers/incidents/incidents.service.spec.ts
+++ b/src/controllers/incidents/incidents.service.spec.ts
@@ -14,12 +14,20 @@ import { IdPathParams } from '../../dto/id-path-params.dto';
 import { RecordType } from '../../common/constants/enumerations';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
-import { idName } from '../../common/constants/parameter-constants';
+import {
+  idName,
+  incidentsAttachmentsFieldName,
+} from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
+import {
+  AttachmentsSingleResponseIncidentExample,
+  AttachmentsEntity,
+} from '../../entities/attachments.entity';
 
 describe('IncidentsService', () => {
   let service: IncidentsService;
   let supportNetworkService: SupportNetworkService;
+  let attachmentsService: AttachmentsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -45,6 +53,7 @@ describe('IncidentsService', () => {
     supportNetworkService = module.get<SupportNetworkService>(
       SupportNetworkService,
     );
+    attachmentsService = module.get<AttachmentsService>(AttachmentsService);
   });
 
   it('should be defined', () => {
@@ -79,6 +88,36 @@ describe('IncidentsService', () => {
           sinceQueryParams,
         );
         expect(result).toEqual(new SupportNetworkEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleIncidentAttachmentRecord tests', () => {
+    it.each([
+      [
+        AttachmentsSingleResponseIncidentExample,
+        { [idName]: 'test' } as IdPathParams,
+        { since: '2024-12-01' } as SinceQueryParams,
+        incidentsAttachmentsFieldName,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams, sinceQueryParams, typeFieldName) => {
+        const attachmentsSpy = jest
+          .spyOn(attachmentsService, 'getSingleAttachmentRecord')
+          .mockReturnValueOnce(Promise.resolve(new AttachmentsEntity(data)));
+
+        const result = await service.getSingleIncidentAttachmentRecord(
+          idPathParams,
+          sinceQueryParams,
+        );
+        expect(attachmentsSpy).toHaveBeenCalledWith(
+          RecordType.Incident,
+          idPathParams,
+          typeFieldName,
+          sinceQueryParams,
+        );
+        expect(result).toEqual(new AttachmentsEntity(data));
       },
     );
   });

--- a/src/controllers/incidents/incidents.service.spec.ts
+++ b/src/controllers/incidents/incidents.service.spec.ts
@@ -15,6 +15,7 @@ import { RecordType } from '../../common/constants/enumerations';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import { idName } from '../../common/constants/parameter-constants';
+import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 
 describe('IncidentsService', () => {
   let service: IncidentsService;
@@ -26,6 +27,7 @@ describe('IncidentsService', () => {
       providers: [
         IncidentsService,
         SupportNetworkService,
+        AttachmentsService,
         UtilitiesService,
         TokenRefresherService,
         RequestPreparerService,

--- a/src/controllers/incidents/incidents.service.ts
+++ b/src/controllers/incidents/incidents.service.ts
@@ -7,10 +7,19 @@ import {
 } from '../../entities/support-network.entity';
 import { IdPathParams } from '../../dto/id-path-params.dto';
 import { SinceQueryParams } from '../../dto/since-query-params.dto';
+import { AttachmentsService } from '../../helpers/attachments/attachments.service';
+import { incidentsAttachmentsFieldName } from '../../common/constants/parameter-constants';
+import {
+  AttachmentsEntity,
+  NestedAttachmentsEntity,
+} from '../../entities/attachments.entity';
 
 @Injectable()
 export class IncidentsService {
-  constructor(private readonly supportNetworkService: SupportNetworkService) {}
+  constructor(
+    private readonly supportNetworkService: SupportNetworkService,
+    private readonly attachmentsService: AttachmentsService,
+  ) {}
 
   async getSingleIncidentSupportNetworkInformationRecord(
     id: IdPathParams,
@@ -19,6 +28,18 @@ export class IncidentsService {
     return await this.supportNetworkService.getSingleSupportNetworkInformationRecord(
       RecordType.Incident,
       id,
+      since,
+    );
+  }
+
+  async getSingleIncidentAttachmentRecord(
+    id: IdPathParams,
+    since?: SinceQueryParams,
+  ): Promise<AttachmentsEntity | NestedAttachmentsEntity> {
+    return await this.attachmentsService.getSingleAttachmentRecord(
+      RecordType.Incident,
+      id,
+      incidentsAttachmentsFieldName,
       since,
     );
   }

--- a/src/controllers/memos/memos.controller.spec.ts
+++ b/src/controllers/memos/memos.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MemosController } from './memos.controller';
+
+describe('MemosController', () => {
+  let controller: MemosController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MemosController],
+    }).compile();
+
+    controller = module.get<MemosController>(MemosController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/controllers/memos/memos.controller.spec.ts
+++ b/src/controllers/memos/memos.controller.spec.ts
@@ -1,11 +1,30 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { MemosController } from './memos.controller';
+import { HttpService } from '@nestjs/axios';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
+import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
+import { AttachmentsService } from '../../helpers/attachments/attachments.service';
+import { UtilitiesService } from '../../helpers/utilities/utilities.service';
+import { MemosService } from './memos.service';
 
 describe('MemosController', () => {
   let controller: MemosController;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot()],
+      providers: [
+        MemosService,
+        AttachmentsService,
+        TokenRefresherService,
+        RequestPreparerService,
+        { provide: CACHE_MANAGER, useValue: {} },
+        ConfigService,
+        UtilitiesService,
+        { provide: HttpService, useValue: { get: jest.fn() } },
+      ],
       controllers: [MemosController],
     }).compile();
 

--- a/src/controllers/memos/memos.controller.spec.ts
+++ b/src/controllers/memos/memos.controller.spec.ts
@@ -8,9 +8,17 @@ import { TokenRefresherService } from '../../external-api/token-refresher/token-
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import { MemosService } from './memos.service';
+import { idName } from '../../common/constants/parameter-constants';
+import { IdPathParams } from '../../dto/id-path-params.dto';
+import { SinceQueryParams } from '../../dto/since-query-params.dto';
+import {
+  AttachmentsSingleResponseMemoExample,
+  AttachmentsEntity,
+} from '../../entities/attachments.entity';
 
 describe('MemosController', () => {
   let controller: MemosController;
+  let memosService: MemosService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -29,9 +37,37 @@ describe('MemosController', () => {
     }).compile();
 
     controller = module.get<MemosController>(MemosController);
+    memosService = module.get<MemosService>(MemosService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('getSingleMemoAttachmentRecord tests', () => {
+    it.each([
+      [
+        AttachmentsSingleResponseMemoExample,
+        { [idName]: 'test' } as IdPathParams,
+        { since: '2020-02-02' } as SinceQueryParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams, sinceQueryParams) => {
+        const memoServiceSpy = jest
+          .spyOn(memosService, 'getSingleMemoAttachmentRecord')
+          .mockReturnValueOnce(Promise.resolve(new AttachmentsEntity(data)));
+
+        const result = await controller.getSingleMemoAttachmentRecord(
+          idPathParams,
+          sinceQueryParams,
+        );
+        expect(memoServiceSpy).toHaveBeenCalledWith(
+          idPathParams,
+          sinceQueryParams,
+        );
+        expect(result).toEqual(new AttachmentsEntity(data));
+      },
+    );
   });
 });

--- a/src/controllers/memos/memos.controller.ts
+++ b/src/controllers/memos/memos.controller.ts
@@ -1,4 +1,90 @@
-import { Controller } from '@nestjs/common';
+import {
+  ClassSerializerInterceptor,
+  Controller,
+  Get,
+  Param,
+  Query,
+  UseInterceptors,
+  ValidationPipe,
+} from '@nestjs/common';
+import { MemosService } from './memos.service';
+import {
+  ApiOperation,
+  ApiQuery,
+  ApiExtraModels,
+  ApiOkResponse,
+  getSchemaPath,
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+} from '@nestjs/swagger';
+import {
+  idName,
+  CONTENT_TYPE,
+} from '../../common/constants/parameter-constants';
+import { IdPathParams } from '../../dto/id-path-params.dto';
+import { SinceQueryParams } from '../../dto/since-query-params.dto';
+import {
+  AttachmentsEntity,
+  NestedAttachmentsEntity,
+  AttachmentsSingleResponseMemoExample,
+  AttachmentsListResponseMemoExample,
+} from '../../entities/attachments.entity';
+import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
+import { ApiNotFoundEntity } from '../../entities/api-not-found.entity';
 
 @Controller('memo')
-export class MemosController {}
+@ApiNotFoundResponse({ type: ApiNotFoundEntity })
+@ApiInternalServerErrorResponse({ type: ApiInternalServerErrorEntity })
+export class MemosController {
+  constructor(private readonly memosService: MemosService) {}
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Get(`:${idName}/attachments`)
+  @ApiOperation({
+    description:
+      'Find all Attachments metadata entries related to a given Memo entity by Memo id.',
+  })
+  @ApiQuery({ name: 'since', required: false })
+  @ApiExtraModels(AttachmentsEntity, NestedAttachmentsEntity)
+  @ApiOkResponse({
+    content: {
+      [CONTENT_TYPE]: {
+        schema: {
+          oneOf: [
+            { $ref: getSchemaPath(AttachmentsEntity) },
+            { $ref: getSchemaPath(NestedAttachmentsEntity) },
+          ],
+        },
+        examples: {
+          AttachmentsSingleResponse: {
+            value: AttachmentsSingleResponseMemoExample,
+          },
+          AttachmentsListResponse: {
+            value: AttachmentsListResponseMemoExample,
+          },
+        },
+      },
+    },
+  })
+  async getSingleMemoAttachmentRecord(
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: IdPathParams,
+    @Query(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+        skipMissingProperties: true,
+      }),
+    )
+    since?: SinceQueryParams,
+  ): Promise<AttachmentsEntity | NestedAttachmentsEntity> {
+    return await this.memosService.getSingleMemoAttachmentRecord(id, since);
+  }
+}

--- a/src/controllers/memos/memos.controller.ts
+++ b/src/controllers/memos/memos.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('memo')
+export class MemosController {}

--- a/src/controllers/memos/memos.module.ts
+++ b/src/controllers/memos/memos.module.ts
@@ -1,9 +1,23 @@
 import { Module } from '@nestjs/common';
 import { MemosService } from './memos.service';
 import { MemosController } from './memos.controller';
+import { ConfigService } from '@nestjs/config';
+import { AuthService } from '../../common/guards/auth/auth.service';
+import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
+import { UtilitiesService } from '../../helpers/utilities/utilities.service';
+import { HttpModule } from '@nestjs/axios';
+import { AuthModule } from '../../common/guards/auth/auth.module';
+import { HelpersModule } from '../../helpers/helpers.module';
 
 @Module({
-  providers: [MemosService],
+  providers: [
+    MemosService,
+    AuthService,
+    ConfigService,
+    UtilitiesService,
+    TokenRefresherService,
+  ],
   controllers: [MemosController],
+  imports: [HelpersModule, AuthModule, HttpModule],
 })
 export class MemosModule {}

--- a/src/controllers/memos/memos.module.ts
+++ b/src/controllers/memos/memos.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { MemosService } from './memos.service';
+import { MemosController } from './memos.controller';
+
+@Module({
+  providers: [MemosService],
+  controllers: [MemosController],
+})
+export class MemosModule {}

--- a/src/controllers/memos/memos.service.spec.ts
+++ b/src/controllers/memos/memos.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MemosService } from './memos.service';
+
+describe('MemosService', () => {
+  let service: MemosService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MemosService],
+    }).compile();
+
+    service = module.get<MemosService>(MemosService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/controllers/memos/memos.service.spec.ts
+++ b/src/controllers/memos/memos.service.spec.ts
@@ -1,12 +1,34 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { MemosService } from './memos.service';
+import { ConfigModule } from '@nestjs/config';
+import { HttpService } from '@nestjs/axios';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
+import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
+import { AttachmentsService } from '../../helpers/attachments/attachments.service';
+import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 
 describe('MemosService', () => {
   let service: MemosService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [MemosService],
+      imports: [ConfigModule.forRoot()],
+      providers: [
+        MemosService,
+        AttachmentsService,
+        UtilitiesService,
+        TokenRefresherService,
+        RequestPreparerService,
+        { provide: HttpService, useValue: { get: jest.fn() } },
+        {
+          provide: CACHE_MANAGER,
+          useValue: {
+            set: () => jest.fn(),
+            get: () => 'Bearer token',
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<MemosService>(MemosService);

--- a/src/controllers/memos/memos.service.spec.ts
+++ b/src/controllers/memos/memos.service.spec.ts
@@ -7,9 +7,21 @@ import { RequestPreparerService } from '../../external-api/request-preparer/requ
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import { UtilitiesService } from '../../helpers/utilities/utilities.service';
+import {
+  AttachmentsEntity,
+  AttachmentsSingleResponseMemoExample,
+} from '../../entities/attachments.entity';
+import { RecordType } from '../../common/constants/enumerations';
+import {
+  idName,
+  memoAttachmentsFieldName,
+} from '../../common/constants/parameter-constants';
+import { IdPathParams } from '../../dto/id-path-params.dto';
+import { SinceQueryParams } from '../../dto/since-query-params.dto';
 
 describe('MemosService', () => {
   let service: MemosService;
+  let attachmentsService: AttachmentsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -32,9 +44,40 @@ describe('MemosService', () => {
     }).compile();
 
     service = module.get<MemosService>(MemosService);
+    attachmentsService = module.get<AttachmentsService>(AttachmentsService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getSingleMemoAttachmentRecord tests', () => {
+    it.each([
+      [
+        AttachmentsSingleResponseMemoExample,
+        { [idName]: 'test' } as IdPathParams,
+        { since: '2024-12-01' } as SinceQueryParams,
+        memoAttachmentsFieldName,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams, sinceQueryParams, typeFieldName) => {
+        const attachmentsSpy = jest
+          .spyOn(attachmentsService, 'getSingleAttachmentRecord')
+          .mockReturnValueOnce(Promise.resolve(new AttachmentsEntity(data)));
+
+        const result = await service.getSingleMemoAttachmentRecord(
+          idPathParams,
+          sinceQueryParams,
+        );
+        expect(attachmentsSpy).toHaveBeenCalledWith(
+          RecordType.Memo,
+          idPathParams,
+          typeFieldName,
+          sinceQueryParams,
+        );
+        expect(result).toEqual(new AttachmentsEntity(data));
+      },
+    );
   });
 });

--- a/src/controllers/memos/memos.service.ts
+++ b/src/controllers/memos/memos.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class MemosService {}

--- a/src/controllers/memos/memos.service.ts
+++ b/src/controllers/memos/memos.service.ts
@@ -1,4 +1,27 @@
 import { Injectable } from '@nestjs/common';
+import { RecordType } from '../../common/constants/enumerations';
+import { memoAttachmentsFieldName } from '../../common/constants/parameter-constants';
+import { IdPathParams } from '../../dto/id-path-params.dto';
+import { SinceQueryParams } from '../../dto/since-query-params.dto';
+import {
+  AttachmentsEntity,
+  NestedAttachmentsEntity,
+} from '../../entities/attachments.entity';
+import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 
 @Injectable()
-export class MemosService {}
+export class MemosService {
+  constructor(private readonly attachmentsService: AttachmentsService) {}
+
+  async getSingleMemoAttachmentRecord(
+    id: IdPathParams,
+    since?: SinceQueryParams,
+  ): Promise<AttachmentsEntity | NestedAttachmentsEntity> {
+    return await this.attachmentsService.getSingleAttachmentRecord(
+      RecordType.Memo,
+      id,
+      memoAttachmentsFieldName,
+      since,
+    );
+  }
+}

--- a/src/controllers/service-requests/service-requests.controller.spec.ts
+++ b/src/controllers/service-requests/service-requests.controller.spec.ts
@@ -15,6 +15,7 @@ import { TokenRefresherService } from '../../external-api/token-refresher/token-
 import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import { idName } from '../../common/constants/parameter-constants';
+import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 
 describe('ServiceRequestsController', () => {
   let controller: ServiceRequestsController;
@@ -26,6 +27,7 @@ describe('ServiceRequestsController', () => {
       providers: [
         ServiceRequestsService,
         SupportNetworkService,
+        AttachmentsService,
         TokenRefresherService,
         RequestPreparerService,
         { provide: CACHE_MANAGER, useValue: {} },

--- a/src/controllers/service-requests/service-requests.controller.spec.ts
+++ b/src/controllers/service-requests/service-requests.controller.spec.ts
@@ -16,6 +16,10 @@ import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import { idName } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
+import {
+  AttachmentsEntity,
+  AttachmentsSingleResponseSRExample,
+} from '../../entities/attachments.entity';
 
 describe('ServiceRequestsController', () => {
   let controller: ServiceRequestsController;
@@ -77,6 +81,33 @@ describe('ServiceRequestsController', () => {
           sinceQueryParams,
         );
         expect(result).toEqual(new SupportNetworkEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleSRAttachmentRecord tests', () => {
+    it.each([
+      [
+        AttachmentsSingleResponseSRExample,
+        { [idName]: 'test' } as IdPathParams,
+        { since: '2020-02-02' } as SinceQueryParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams, sinceQueryParams) => {
+        const SRsServiceSpy = jest
+          .spyOn(serviceRequestsService, 'getSingleSRAttachmentRecord')
+          .mockReturnValueOnce(Promise.resolve(new AttachmentsEntity(data)));
+
+        const result = await controller.getSingleSRAttachmentRecord(
+          idPathParams,
+          sinceQueryParams,
+        );
+        expect(SRsServiceSpy).toHaveBeenCalledWith(
+          idPathParams,
+          sinceQueryParams,
+        );
+        expect(result).toEqual(new AttachmentsEntity(data));
       },
     );
   });

--- a/src/controllers/service-requests/service-requests.controller.spec.ts
+++ b/src/controllers/service-requests/service-requests.controller.spec.ts
@@ -23,7 +23,6 @@ import {
 
 import { AuthService } from '../../common/guards/auth/auth.service';
 
-
 describe('ServiceRequestsController', () => {
   let controller: ServiceRequestsController;
   let serviceRequestsService: ServiceRequestsService;

--- a/src/controllers/service-requests/service-requests.controller.ts
+++ b/src/controllers/service-requests/service-requests.controller.ts
@@ -31,6 +31,12 @@ import {
   idName,
 } from '../../common/constants/parameter-constants';
 import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
+import {
+  AttachmentsEntity,
+  AttachmentsListResponseSRExample,
+  AttachmentsSingleResponseSRExample,
+  NestedAttachmentsEntity,
+} from '../../entities/attachments.entity';
 
 @Controller('sr')
 @ApiNotFoundResponse({ type: ApiNotFoundEntity })
@@ -86,6 +92,59 @@ export class ServiceRequestsController {
     since?: SinceQueryParams,
   ): Promise<SupportNetworkEntity | NestedSupportNetworkEntity> {
     return await this.serviceRequestService.getSingleSRSupportNetworkInformationRecord(
+      id,
+      since,
+    );
+  }
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Get(`:${idName}/attachments`)
+  @ApiOperation({
+    description:
+      'Find all Attachments metadata entries related to a given Service Request entity by Service Request id.',
+  })
+  @ApiQuery({ name: 'since', required: false })
+  @ApiExtraModels(AttachmentsEntity, NestedAttachmentsEntity)
+  @ApiOkResponse({
+    content: {
+      [CONTENT_TYPE]: {
+        schema: {
+          oneOf: [
+            { $ref: getSchemaPath(AttachmentsEntity) },
+            { $ref: getSchemaPath(NestedAttachmentsEntity) },
+          ],
+        },
+        examples: {
+          AttachmentsSingleResponse: {
+            value: AttachmentsSingleResponseSRExample,
+          },
+          AttachmentsListResponse: {
+            value: AttachmentsListResponseSRExample,
+          },
+        },
+      },
+    },
+  })
+  async getSingleSRAttachmentRecord(
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: IdPathParams,
+    @Query(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+        skipMissingProperties: true,
+      }),
+    )
+    since?: SinceQueryParams,
+  ): Promise<AttachmentsEntity | NestedAttachmentsEntity> {
+    return await this.serviceRequestService.getSingleSRAttachmentRecord(
       id,
       since,
     );

--- a/src/controllers/service-requests/service-requests.service.spec.ts
+++ b/src/controllers/service-requests/service-requests.service.spec.ts
@@ -15,6 +15,7 @@ import { SinceQueryParams } from '../../dto/since-query-params.dto';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import { idName } from '../../common/constants/parameter-constants';
+import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 
 describe('ServiceRequestsService', () => {
   let service: ServiceRequestsService;
@@ -26,6 +27,7 @@ describe('ServiceRequestsService', () => {
       providers: [
         ServiceRequestsService,
         SupportNetworkService,
+        AttachmentsService,
         UtilitiesService,
         TokenRefresherService,
         RequestPreparerService,

--- a/src/controllers/service-requests/service-requests.service.spec.ts
+++ b/src/controllers/service-requests/service-requests.service.spec.ts
@@ -14,12 +14,20 @@ import { IdPathParams } from '../../dto/id-path-params.dto';
 import { SinceQueryParams } from '../../dto/since-query-params.dto';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
-import { idName } from '../../common/constants/parameter-constants';
+import {
+  idName,
+  srAttachmentsFieldName,
+} from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
+import {
+  AttachmentsEntity,
+  AttachmentsSingleResponseSRExample,
+} from '../../entities/attachments.entity';
 
 describe('ServiceRequestsService', () => {
   let service: ServiceRequestsService;
   let supportNetworkService: SupportNetworkService;
+  let attachmentsService: AttachmentsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -46,6 +54,7 @@ describe('ServiceRequestsService', () => {
     supportNetworkService = module.get<SupportNetworkService>(
       SupportNetworkService,
     );
+    attachmentsService = module.get<AttachmentsService>(AttachmentsService);
   });
 
   it('should be defined', () => {
@@ -79,6 +88,36 @@ describe('ServiceRequestsService', () => {
           sinceQueryParams,
         );
         expect(result).toEqual(new SupportNetworkEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleSRAttachmentRecord tests', () => {
+    it.each([
+      [
+        AttachmentsSingleResponseSRExample,
+        { [idName]: 'test' } as IdPathParams,
+        { since: '2024-12-01' } as SinceQueryParams,
+        srAttachmentsFieldName,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams, sinceQueryParams, typeFieldName) => {
+        const attachmentsSpy = jest
+          .spyOn(attachmentsService, 'getSingleAttachmentRecord')
+          .mockReturnValueOnce(Promise.resolve(new AttachmentsEntity(data)));
+
+        const result = await service.getSingleSRAttachmentRecord(
+          idPathParams,
+          sinceQueryParams,
+        );
+        expect(attachmentsSpy).toHaveBeenCalledWith(
+          RecordType.SR,
+          idPathParams,
+          typeFieldName,
+          sinceQueryParams,
+        );
+        expect(result).toEqual(new AttachmentsEntity(data));
       },
     );
   });

--- a/src/controllers/service-requests/service-requests.service.ts
+++ b/src/controllers/service-requests/service-requests.service.ts
@@ -7,10 +7,19 @@ import {
 } from '../../entities/support-network.entity';
 import { IdPathParams } from '../../dto/id-path-params.dto';
 import { SinceQueryParams } from '../../dto/since-query-params.dto';
+import { AttachmentsService } from '../../helpers/attachments/attachments.service';
+import { srAttachmentsFieldName } from '../../common/constants/parameter-constants';
+import {
+  AttachmentsEntity,
+  NestedAttachmentsEntity,
+} from '../../entities/attachments.entity';
 
 @Injectable()
 export class ServiceRequestsService {
-  constructor(private readonly supportNetworkService: SupportNetworkService) {}
+  constructor(
+    private readonly supportNetworkService: SupportNetworkService,
+    private readonly attachmentsService: AttachmentsService,
+  ) {}
 
   async getSingleSRSupportNetworkInformationRecord(
     id: IdPathParams,
@@ -19,6 +28,18 @@ export class ServiceRequestsService {
     return await this.supportNetworkService.getSingleSupportNetworkInformationRecord(
       RecordType.SR,
       id,
+      since,
+    );
+  }
+
+  async getSingleSRAttachmentRecord(
+    id: IdPathParams,
+    since?: SinceQueryParams,
+  ): Promise<AttachmentsEntity | NestedAttachmentsEntity> {
+    return await this.attachmentsService.getSingleAttachmentRecord(
+      RecordType.SR,
+      id,
+      srAttachmentsFieldName,
       since,
     );
   }

--- a/src/entities/attachments.entity.ts
+++ b/src/entities/attachments.entity.ts
@@ -1,0 +1,364 @@
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+import { Exclude, Expose, Type } from 'class-transformer';
+
+/*
+ * Examples
+ */
+// TODO: Replace 'string' with something meaningful when I can actually hit the endpoint
+export const AttachmentsSingleResponseCaseExample = {
+  'Application No': 'string',
+  Categorie: 'string',
+  Category: 'string',
+  'Client Flag': 'string',
+  'End Date': 'string',
+  'Final Flag': 'string',
+  'Form Description': 'string',
+  'Incident Id': '',
+  'Incident No': '',
+  Internal: 'string',
+  'Last Updated Date': 'string',
+  'No Intervention': 'string',
+  'Portal Visible': 'string',
+  'Show on Contact': 'string',
+  Status: 'string',
+  'Sub-Category': 'string',
+  Template: 'string',
+  'Template Type': 'string',
+  'Case Id': 'string',
+  Comments: 'string',
+  'Created Date': 'string',
+  CreatedByName: 'string',
+  FileAutoUpdFlg: 'string',
+  FileDate: 'string',
+  FileDeferFlg: 'string',
+  FileDockReqFlg: 'string',
+  FileDockStatFlg: 'string',
+  FileExt: 'string',
+  FileSize: 'string',
+  FileSrcPath: 'string',
+  FileSrcType: 'string',
+  UpdatedByName: 'string',
+  FileName: 'string',
+  'Memo Id': '',
+  MemoNumber: 'string',
+  'SR Id': '',
+  'Attachment Id': 'string',
+  Id: 'string',
+};
+
+export const AttachmentsSingleResponseIncidentExample = {
+  ...AttachmentsSingleResponseCaseExample,
+  'Case Id': '',
+  'Incident Id': 'Incident-Id-Here',
+  'Incident No': 'Incident-No-Here',
+};
+
+export const AttachmentsSingleResponseSRExample = {
+  ...AttachmentsSingleResponseCaseExample,
+  'Case Id': '',
+  'SR Id': 'SR-Id-Here',
+};
+
+export const AttachmentsSingleResponseMemoExample = {
+  ...AttachmentsSingleResponseCaseExample,
+  'Case Id': '',
+  'Memo Id': 'Memo-Id-Here',
+};
+
+export const AttachmentsListResponseCaseExample = {
+  items: [
+    AttachmentsSingleResponseCaseExample,
+    {
+      ...AttachmentsSingleResponseCaseExample,
+      'Case Id': 'Another-Id-here',
+    },
+  ],
+};
+
+export const AttachmentsListResponseIncidentExample = {
+  items: [
+    AttachmentsSingleResponseIncidentExample,
+    {
+      ...AttachmentsSingleResponseIncidentExample,
+      'Incident Id': 'Another-Incident-Id-Here',
+      'Incident No': 'Another-Incident-No-Here',
+    },
+  ],
+};
+
+export const AttachmentsListResponseSRExample = {
+  items: [
+    AttachmentsSingleResponseSRExample,
+    {
+      ...AttachmentsSingleResponseSRExample,
+      'SR Id': 'Another-SR-Id-Here',
+    },
+  ],
+};
+
+export const AttachmentsListResponseMemoExample = {
+  items: [
+    AttachmentsSingleResponseMemoExample,
+    {
+      ...AttachmentsSingleResponseMemoExample,
+      'Memo Id': 'Another-Memo-Id-Here',
+    },
+  ],
+};
+
+/*
+ * Model definitions
+ */
+@Exclude()
+@ApiSchema({ name: 'AttachmentsSingleResponse' })
+export class AttachmentsEntity {
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Name'],
+  })
+  @Expose()
+  Name: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Application No'],
+  })
+  @Expose()
+  'Application No': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Categorie'],
+  })
+  @Expose()
+  Categorie: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Category'],
+  })
+  @Expose()
+  Category: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Client Flag'],
+  })
+  @Expose()
+  'Client Flag': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['End Date'],
+  })
+  @Expose()
+  'End Date': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Final Flag'],
+  })
+  @Expose()
+  'Final Flag': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Form Description'],
+  })
+  @Expose()
+  'Form Description': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Incident Id'],
+  })
+  @Expose()
+  'Incident Id': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Incident No'],
+  })
+  @Expose()
+  'Incident No': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Internal'],
+  })
+  @Expose()
+  Internal: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Last Updated Date'],
+  })
+  @Expose()
+  'Last Updated Date': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['No Intervention'],
+  })
+  @Expose()
+  'No Intervention': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Portal Visible'],
+  })
+  @Expose()
+  'Portal Visible': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Show on Contact'],
+  })
+  @Expose()
+  'Show on Contact': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Status'],
+  })
+  @Expose()
+  Status: string;
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Sub-Category'],
+  })
+  @Expose()
+  'Sub-Category': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Template'],
+  })
+  @Expose()
+  Template: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Template Type'],
+  })
+  @Expose()
+  'Template Type': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Case Id'],
+  })
+  @Expose()
+  'Case Id': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Comments'],
+  })
+  @Expose()
+  Comments: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Created Date'],
+  })
+  @Expose()
+  'Created Date': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['CreatedByName'],
+  })
+  @Expose()
+  CreatedByName: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['FileAutoUpdFlg'],
+  })
+  @Expose()
+  FileAutoUpdFlg: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['FileDate'],
+  })
+  @Expose()
+  FileDate: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['FileDeferFlg'],
+  })
+  @Expose()
+  FileDeferFlg: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['FileDockReqFlg'],
+  })
+  @Expose()
+  FileDockReqFlg: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['FileDockStatFlg'],
+  })
+  @Expose()
+  FileDockStatFlg: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['FileExt'],
+  })
+  @Expose()
+  FileExt: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['FileSize'],
+  })
+  @Expose()
+  FileSize: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['FileSrcPath'],
+  })
+  @Expose()
+  FileSrcPath: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['FileSrcType'],
+  })
+  @Expose()
+  FileSrcType: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['  UpdatedByName'],
+  })
+  @Expose()
+  UpdatedByName: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['  FileName'],
+  })
+  @Expose()
+  FileName: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Memo Id'],
+  })
+  @Expose()
+  'Memo Id': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['  MemoNumber'],
+  })
+  @Expose()
+  MemoNumber: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['SR Id'],
+  })
+  @Expose()
+  'SR Id': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['Attachment Id'],
+  })
+  @Expose()
+  'Attachment Id': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['  Id'],
+  })
+  @Expose()
+  Id: string;
+
+  constructor(partial: Partial<AttachmentsEntity>) {
+    Object.assign(this, partial);
+  }
+}
+
+@Exclude()
+@ApiSchema({ name: 'AttachmentsListResponse' })
+export class NestedAttachmentsEntity {
+  @Expose()
+  @ApiProperty({ type: AttachmentsEntity, isArray: true })
+  @Type(() => AttachmentsEntity)
+  items: Array<AttachmentsEntity>;
+
+  constructor(object) {
+    Object.assign(this, object);
+  }
+}

--- a/src/entities/attachments.entity.ts
+++ b/src/entities/attachments.entity.ts
@@ -302,13 +302,13 @@ export class AttachmentsEntity {
   FileSrcType: string;
 
   @ApiProperty({
-    example: AttachmentsSingleResponseCaseExample['  UpdatedByName'],
+    example: AttachmentsSingleResponseCaseExample['UpdatedByName'],
   })
   @Expose()
   UpdatedByName: string;
 
   @ApiProperty({
-    example: AttachmentsSingleResponseCaseExample['  FileName'],
+    example: AttachmentsSingleResponseCaseExample['FileName'],
   })
   @Expose()
   FileName: string;
@@ -320,7 +320,7 @@ export class AttachmentsEntity {
   'Memo Id': string;
 
   @ApiProperty({
-    example: AttachmentsSingleResponseCaseExample['  MemoNumber'],
+    example: AttachmentsSingleResponseCaseExample['MemoNumber'],
   })
   @Expose()
   MemoNumber: string;
@@ -338,7 +338,7 @@ export class AttachmentsEntity {
   'Attachment Id': string;
 
   @ApiProperty({
-    example: AttachmentsSingleResponseCaseExample['  Id'],
+    example: AttachmentsSingleResponseCaseExample['Id'],
   })
   @Expose()
   Id: string;

--- a/src/entities/attachments.entity.ts
+++ b/src/entities/attachments.entity.ts
@@ -6,7 +6,7 @@ import { Exclude, Expose, Type } from 'class-transformer';
  */
 // TODO: Replace 'string' with something meaningful when I can actually hit the endpoint
 export const AttachmentsSingleResponseCaseExample = {
-  'Application No': 'string',
+  'Application No': '',
   Categorie: 'string',
   Category: 'string',
   'Client Flag': 'string',
@@ -17,7 +17,7 @@ export const AttachmentsSingleResponseCaseExample = {
   'Incident No': '',
   Internal: 'string',
   'Last Updated Date': 'string',
-  'No Intervention': 'string',
+  'No Intervention': 'Case-Id-Here',
   'Portal Visible': 'string',
   'Show on Contact': 'string',
   Status: 'string',
@@ -40,7 +40,7 @@ export const AttachmentsSingleResponseCaseExample = {
   UpdatedByName: 'string',
   FileName: 'string',
   'Memo Id': '',
-  MemoNumber: 'string',
+  MemoNumber: '',
   'SR Id': '',
   'Attachment Id': 'string',
   Id: 'string',
@@ -48,21 +48,20 @@ export const AttachmentsSingleResponseCaseExample = {
 
 export const AttachmentsSingleResponseIncidentExample = {
   ...AttachmentsSingleResponseCaseExample,
-  'Case Id': '',
-  'Incident Id': 'Incident-Id-Here',
-  'Incident No': 'Incident-No-Here',
+  'No Intervention': '',
+  'Incident No': 'Incident-Id-Here',
 };
 
 export const AttachmentsSingleResponseSRExample = {
   ...AttachmentsSingleResponseCaseExample,
-  'Case Id': '',
-  'SR Id': 'SR-Id-Here',
+  'No Intervention': '',
+  'Application No': 'SR-Id-Here',
 };
 
 export const AttachmentsSingleResponseMemoExample = {
   ...AttachmentsSingleResponseCaseExample,
-  'Case Id': '',
-  'Memo Id': 'Memo-Id-Here',
+  'No Intervention': '',
+  MemoNumber: 'Memo-Id-Here',
 };
 
 export const AttachmentsListResponseCaseExample = {
@@ -70,7 +69,7 @@ export const AttachmentsListResponseCaseExample = {
     AttachmentsSingleResponseCaseExample,
     {
       ...AttachmentsSingleResponseCaseExample,
-      'Case Id': 'Another-Id-here',
+      'No Intervention': 'Another-Case-Id-Here',
     },
   ],
 };
@@ -80,8 +79,7 @@ export const AttachmentsListResponseIncidentExample = {
     AttachmentsSingleResponseIncidentExample,
     {
       ...AttachmentsSingleResponseIncidentExample,
-      'Incident Id': 'Another-Incident-Id-Here',
-      'Incident No': 'Another-Incident-No-Here',
+      'Incident No': 'Another-Incident-Id-Here',
     },
   ],
 };
@@ -91,7 +89,7 @@ export const AttachmentsListResponseSRExample = {
     AttachmentsSingleResponseSRExample,
     {
       ...AttachmentsSingleResponseSRExample,
-      'SR Id': 'Another-SR-Id-Here',
+      'Application No': 'Another-SR-Id-Here',
     },
   ],
 };
@@ -101,7 +99,7 @@ export const AttachmentsListResponseMemoExample = {
     AttachmentsSingleResponseMemoExample,
     {
       ...AttachmentsSingleResponseMemoExample,
-      'Memo Id': 'Another-Memo-Id-Here',
+      MemoNumber: 'Another-Memo-Id-Here',
     },
   ],
 };

--- a/src/helpers/attachments/attachments.module.ts
+++ b/src/helpers/attachments/attachments.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { AttachmentsService } from './attachments.service';
+
+@Module({
+  providers: [AttachmentsService],
+})
+export class AttachmentsModule {}

--- a/src/helpers/attachments/attachments.module.ts
+++ b/src/helpers/attachments/attachments.module.ts
@@ -1,7 +1,20 @@
 import { Module } from '@nestjs/common';
 import { AttachmentsService } from './attachments.service';
+import { HttpModule } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
+import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
+import { UtilitiesService } from '../utilities/utilities.service';
 
 @Module({
-  providers: [AttachmentsService],
+  imports: [HttpModule],
+  providers: [
+    AttachmentsService,
+    ConfigService,
+    RequestPreparerService,
+    UtilitiesService,
+    TokenRefresherService,
+  ],
+  exports: [AttachmentsService],
 })
 export class AttachmentsModule {}

--- a/src/helpers/attachments/attachments.service.spec.ts
+++ b/src/helpers/attachments/attachments.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AttachmentsService } from './attachments.service';
+
+describe('AttachmentsService', () => {
+  let service: AttachmentsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AttachmentsService],
+    }).compile();
+
+    service = module.get<AttachmentsService>(AttachmentsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/helpers/attachments/attachments.service.spec.ts
+++ b/src/helpers/attachments/attachments.service.spec.ts
@@ -1,12 +1,33 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AttachmentsService } from './attachments.service';
+import { HttpService } from '@nestjs/axios';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
+import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
+import { UtilitiesService } from '../utilities/utilities.service';
 
 describe('AttachmentsService', () => {
   let service: AttachmentsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AttachmentsService],
+      imports: [ConfigModule.forRoot()],
+      providers: [
+        AttachmentsService,
+        UtilitiesService,
+        ConfigService,
+        TokenRefresherService,
+        RequestPreparerService,
+        { provide: HttpService, useValue: { get: jest.fn() } },
+        {
+          provide: CACHE_MANAGER,
+          useValue: {
+            set: () => jest.fn(),
+            get: () => 'Bearer token',
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<AttachmentsService>(AttachmentsService);

--- a/src/helpers/attachments/attachments.service.spec.ts
+++ b/src/helpers/attachments/attachments.service.spec.ts
@@ -6,9 +6,23 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { UtilitiesService } from '../utilities/utilities.service';
+import { RecordType } from '../../common/constants/enumerations';
+import {
+  casesAttachmentsFieldName,
+  idName,
+  incidentsAttachmentsFieldName,
+} from '../../common/constants/parameter-constants';
+import { AxiosResponse } from 'axios';
+import {
+  AttachmentsEntity,
+  AttachmentsListResponseIncidentExample,
+  AttachmentsSingleResponseCaseExample,
+  NestedAttachmentsEntity,
+} from '../../entities/attachments.entity';
 
 describe('AttachmentsService', () => {
   let service: AttachmentsService;
+  let requestPreparerService: RequestPreparerService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -31,9 +45,72 @@ describe('AttachmentsService', () => {
     }).compile();
 
     service = module.get<AttachmentsService>(AttachmentsService);
+    requestPreparerService = module.get<RequestPreparerService>(
+      RequestPreparerService,
+    );
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getSingleAttachmentRecord tests', () => {
+    it.each([
+      [
+        RecordType.Case,
+        { [idName]: 'id' },
+        casesAttachmentsFieldName,
+        AttachmentsSingleResponseCaseExample,
+      ],
+    ])(
+      'should return a single attachment entity given good inputs',
+      async (type, id, typeFieldName, data) => {
+        const spy = jest
+          .spyOn(requestPreparerService, 'sendGetRequest')
+          .mockResolvedValueOnce({
+            data: data,
+            headers: {},
+            status: 200,
+            statusText: 'OK',
+          } as AxiosResponse<any, any>);
+        const result = await service.getSingleAttachmentRecord(
+          type,
+          id,
+          typeFieldName,
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(new AttachmentsEntity(data));
+      },
+    );
+
+    it.each([
+      [
+        RecordType.Incident,
+        { [idName]: 'id' },
+        incidentsAttachmentsFieldName,
+        { since: '2023-11-13' },
+        AttachmentsListResponseIncidentExample,
+      ],
+    ])(
+      'should return a nested attachment entity given good inputs',
+      async (type, id, typeFieldName, since, data) => {
+        const spy = jest
+          .spyOn(requestPreparerService, 'sendGetRequest')
+          .mockResolvedValueOnce({
+            data: data,
+            headers: {},
+            status: 200,
+            statusText: 'OK',
+          } as AxiosResponse<any, any>);
+        const result = await service.getSingleAttachmentRecord(
+          type,
+          id,
+          typeFieldName,
+          since,
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(new NestedAttachmentsEntity(data));
+      },
+    );
   });
 });

--- a/src/helpers/attachments/attachments.service.ts
+++ b/src/helpers/attachments/attachments.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AttachmentsService {}

--- a/src/helpers/attachments/attachments.service.ts
+++ b/src/helpers/attachments/attachments.service.ts
@@ -1,4 +1,58 @@
 import { Injectable } from '@nestjs/common';
+import { RecordType } from '../../common/constants/enumerations';
+import { IdPathParams } from '../../dto/id-path-params.dto';
+import { SinceQueryParams } from '../../dto/since-query-params.dto';
+import { ConfigService } from '@nestjs/config';
+import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
+import {
+  NestedAttachmentsEntity,
+  AttachmentsEntity,
+} from '../../entities/attachments.entity';
+import {
+  baseUrlEnvVarName,
+  attachmentsEndpointEnvVarName,
+} from '../../common/constants/upstream-constants';
+import { idName } from '../../common/constants/parameter-constants';
 
 @Injectable()
-export class AttachmentsService {}
+export class AttachmentsService {
+  url: string;
+  workspace: string | undefined;
+  sinceFieldName: string | undefined;
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly requestPreparerService: RequestPreparerService,
+  ) {
+    this.url = (
+      this.configService.get<string>(baseUrlEnvVarName) +
+      this.configService.get<string>(attachmentsEndpointEnvVarName)
+    ).replace(/\s/g, '%20');
+    this.workspace = this.configService.get('workspaces.attachments');
+    this.sinceFieldName = this.configService.get('sinceFieldName.attachments');
+  }
+
+  async getSingleAttachmentRecord(
+    _type: RecordType,
+    id: IdPathParams,
+    typeFieldName: string,
+    since?: SinceQueryParams,
+  ): Promise<AttachmentsEntity | NestedAttachmentsEntity> {
+    const baseSearchSpec = `([${typeFieldName}]="${id[idName]}"`;
+    const [headers, params] =
+      this.requestPreparerService.prepareHeadersAndParams(
+        baseSearchSpec,
+        this.workspace,
+        this.sinceFieldName,
+        since,
+      );
+    const response = await this.requestPreparerService.sendGetRequest(
+      this.url,
+      headers,
+      params,
+    );
+    if ((response.data as object).hasOwnProperty('items')) {
+      return new NestedAttachmentsEntity(response.data);
+    }
+    return new AttachmentsEntity(response.data);
+  }
+}

--- a/src/helpers/helpers.module.ts
+++ b/src/helpers/helpers.module.ts
@@ -11,6 +11,8 @@ import { InPersonVisitsModule } from './in-person-visits/in-person-visits.module
 import { InPersonVisitsService } from './in-person-visits/in-person-visits.service';
 import { RequestPreparerModule } from '../external-api/request-preparer/request-preparer.module';
 import { RequestPreparerService } from '../external-api/request-preparer/request-preparer.service';
+import { AttachmentsModule } from './attachments/attachments.module';
+import { AttachmentsService } from './attachments/attachments.service';
 
 @Module({
   imports: [
@@ -21,6 +23,7 @@ import { RequestPreparerService } from '../external-api/request-preparer/request
     TokenRefresherModule,
     InPersonVisitsModule,
     RequestPreparerModule,
+    AttachmentsModule,
   ],
   providers: [
     SupportNetworkService,
@@ -28,6 +31,7 @@ import { RequestPreparerService } from '../external-api/request-preparer/request
     TokenRefresherService,
     InPersonVisitsService,
     RequestPreparerService,
+    AttachmentsService,
   ],
   exports: [SupportNetworkService, UtilitiesService, InPersonVisitsService],
 })

--- a/src/helpers/helpers.module.ts
+++ b/src/helpers/helpers.module.ts
@@ -33,6 +33,11 @@ import { AttachmentsService } from './attachments/attachments.service';
     RequestPreparerService,
     AttachmentsService,
   ],
-  exports: [SupportNetworkService, UtilitiesService, InPersonVisitsService],
+  exports: [
+    SupportNetworkService,
+    UtilitiesService,
+    InPersonVisitsService,
+    AttachmentsService,
+  ],
 })
 export class HelpersModule {}

--- a/src/helpers/in-person-visits/in-person-visits.service.ts
+++ b/src/helpers/in-person-visits/in-person-visits.service.ts
@@ -29,7 +29,7 @@ export class InPersonVisitsService {
     ).replace(/\s/g, '%20');
     this.workspace = this.configService.get('workspaces.inPersonVisits');
     this.sinceFieldName = this.configService.get(
-      'sinceFieldName.supportNetwork',
+      'sinceFieldName.inPersonVisits',
     );
   }
 


### PR DESCRIPTION
[Story link](https://bcsocialsector.service-now.com/now/nav/ui/classic/params/target/rm_story.do%3Fsys_id%3D3504413d93199610e09fb1584dba1010%26sysparm_view%3Dscrum%26sysparm_record_target%3Drm_story%26sysparm_record_row%3D6%26sysparm_record_rows%3D20%26sysparm_record_list%3Depic%253Db96a9b1d931dd210e09fb1584dba1091%255EORDERBYnumber)

This PR contains the endpoints for the GET /{case|incident|sr|memo}/{rowId}/attachments API. Note that this is based off of an OpenAPI spec given by /describe as the endpoint is not yet available to query.

Includes Swagger definitions and unit tests.