### PR TITLE
POST In Person Visits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ CLIENT_SECRET='secret here'
 UPSTREAM_BASE_URL=http://www.google.com
 SUPPORT_NETWORK_ENDPOINT=/endpoint/path/here
 IN_PERSON_VISITS_ENDPOINT=/endpoint/path/here
+IN_PERSON_VISITS_POST_ENDPOINT=/endpoint/path/here
 CASE_ENDPOINT=/endpoint/path/here
 INCIDENT_ENDPOINT=/endpoint/path/here
 SR_ENDPOINT=/endpoint/path/here

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -92,6 +92,11 @@ spec:
                 secretKeyRef:
                     name: visitz-api
                     key: ATTACHMENTS_ENDPOINT
+            - name: POST_IN_PERSON_VISITS_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                    name: visitz-api
+                    key: POST_IN_PERSON_VISITS_ENDPOINT
             - name: VPI_APP_LABEL
               value: {{ .Values.vpiAppBuildLabel.version }}
       restartPolicy: Always

--- a/src/common/constants/enumerations.ts
+++ b/src/common/constants/enumerations.ts
@@ -17,4 +17,17 @@ const RecordEntityMap = {
   [RecordType.SR]: EntityType.SR,
 } as const;
 
-export { RecordType, EntityType, RecordEntityMap };
+enum VisitDetails {
+  PrivateVisitZeroToFive = 'Private visit age 0-5',
+  PrivateVisitInHome = 'Private visit in home',
+  PrivateVisitMedSupportNeeds = 'Private visit medical or support needs',
+  PrivateVisitNotInHome = 'Private visit not in home',
+  ExemptionVisitChildDeclined = 'Exemption to private visit - Child declined to meet',
+  ExemptionVisitOther = 'Exemption to private visit - Other',
+  NotPrivatePlanMeeting = 'Not private - Planning meeting',
+  NotPrivateRelation = 'Not private - Relational visit',
+  NotPrivateInHome = 'Not private - Visit in the home',
+  NotPrivateCaregiver = 'Not private - Visit with caregiver',
+}
+
+export { RecordType, EntityType, RecordEntityMap, VisitDetails };

--- a/src/common/constants/upstream-constants.ts
+++ b/src/common/constants/upstream-constants.ts
@@ -1,13 +1,23 @@
 const baseUrlEnvVarName = 'UPSTREAM_BASE_URL';
 const supportNetworkEndpointEnvVarName = 'SUPPORT_NETWORK_ENDPOINT';
 const inPersonVisitsEndpointEnvVarName = 'IN_PERSON_VISITS_ENDPOINT';
+const postInPersonVisitsEndpointEnvVarName = 'IN_PERSON_VISITS_POST_ENDPOINT';
 const attachmentsEndpointEnvVarName = 'ATTACHMENTS_ENDPOINT';
 const idirUsernameHeaderField = 'x-idir-username';
+const upstreamDateFormat = 'MM/dd/yyyy HH:mm:ss';
+const childVisitType = 'In Person Child Youth';
+const childVisitIdirFieldName = 'Login Name';
+const childVisitEntityIdFieldName = 'Parent Id';
 
 export {
   baseUrlEnvVarName,
   supportNetworkEndpointEnvVarName,
   inPersonVisitsEndpointEnvVarName,
+  postInPersonVisitsEndpointEnvVarName,
   attachmentsEndpointEnvVarName,
   idirUsernameHeaderField,
+  upstreamDateFormat,
+  childVisitType,
+  childVisitIdirFieldName,
+  childVisitEntityIdFieldName,
 };

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -31,6 +31,7 @@ export default () => ({
     supportNetwork: undefined,
     inPersonVisits: undefined,
     attachments: 'int_lab',
+    postInPersonVisits: 'int_lab',
   },
   sinceFieldName: {
     supportNetwork: 'Updated',

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -15,7 +15,8 @@ export default () => ({
     },
     sr: {
       endpoint: process.env.SR_ENDPOINT.trim().replace(/\s/g, '%20'),
-      workspace: 'dev_sadmin_4426_2',
+      workspace: 'int_lab',
+      idirField: 'Owner',
     },
     memo: {
       endpoint: process.env.MEMO_ENDPOINT.trim().replace(/\s/g, '%20'),

--- a/src/controllers/cases/cases.controller.spec.ts
+++ b/src/controllers/cases/cases.controller.spec.ts
@@ -19,6 +19,8 @@ import { RequestPreparerService } from '../../external-api/request-preparer/requ
 import {
   InPersonVisitsEntity,
   InPersonVisitsSingleResponseCaseExample,
+  NestedInPersonVisitsEntity,
+  PostInPersonVisitResponseExample,
 } from '../../entities/in-person-visits.entity';
 import { idName } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
@@ -26,6 +28,9 @@ import {
   AttachmentsSingleResponseCaseExample,
   AttachmentsEntity,
 } from '../../entities/attachments.entity';
+import { VisitDetails } from '../../common/constants/enumerations';
+import { getMockReq } from '@jest-mock/express';
+import { idirUsernameHeaderField } from '../../common/constants/upstream-constants';
 
 describe('CasesController', () => {
   let controller: CasesController;
@@ -109,6 +114,38 @@ describe('CasesController', () => {
           sinceQueryParams,
         );
         expect(result).toEqual(new InPersonVisitsEntity(data));
+      },
+    );
+  });
+
+  describe('postSingleCaseInPersonVisitRecord tests', () => {
+    it.each([
+      [
+        {
+          'Date of visit': '2024-11-13T21:24:03',
+          'Visit Details Value': VisitDetails.NotPrivateInHome,
+          'Visit Description': 'comment',
+        },
+        { [idName]: 'test' } as IdPathParams,
+        'idir',
+        PostInPersonVisitResponseExample,
+      ],
+    ])(
+      'should return single values given good input',
+      async (body, idPathParams, idir, data) => {
+        const casesServiceSpy = jest
+          .spyOn(casesService, 'postSingleCaseInPersonVisitRecord')
+          .mockReturnValueOnce(
+            Promise.resolve(new NestedInPersonVisitsEntity(data)),
+          );
+
+        const result = await controller.postSingleCaseInPersonVisitRecord(
+          body,
+          idPathParams,
+          getMockReq({ headers: { [idirUsernameHeaderField]: idir } }),
+        );
+        expect(casesServiceSpy).toHaveBeenCalledWith(body, idir, idPathParams);
+        expect(result).toEqual(new NestedInPersonVisitsEntity(data));
       },
     );
   });

--- a/src/controllers/cases/cases.service.spec.ts
+++ b/src/controllers/cases/cases.service.spec.ts
@@ -11,13 +11,15 @@ import {
 } from '../../entities/support-network.entity';
 import { IdPathParams } from '../../dto/id-path-params.dto';
 import { SinceQueryParams } from '../../dto/since-query-params.dto';
-import { RecordType } from '../../common/constants/enumerations';
+import { RecordType, VisitDetails } from '../../common/constants/enumerations';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { InPersonVisitsService } from '../../helpers/in-person-visits/in-person-visits.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import {
   InPersonVisitsEntity,
   InPersonVisitsSingleResponseCaseExample,
+  NestedInPersonVisitsEntity,
+  PostInPersonVisitResponseExample,
 } from '../../entities/in-person-visits.entity';
 import {
   casesAttachmentsFieldName,
@@ -126,6 +128,38 @@ describe('CasesService', () => {
           sinceQueryParams,
         );
         expect(result).toEqual(new InPersonVisitsEntity(data));
+      },
+    );
+  });
+
+  describe('postSingleCaseInPersonVisitRecord tests', () => {
+    it.each([
+      [
+        {
+          'Date of visit': '11/08/2024 08:24:11',
+          'Visit Details Value': VisitDetails.NotPrivateInHome,
+          'Visit Description': 'comment',
+        },
+        'idir',
+        { [idName]: 'test' } as IdPathParams,
+        PostInPersonVisitResponseExample,
+      ],
+    ])(
+      'should return single values given good input',
+      async (body, idir, idPathParams, data) => {
+        const InPersonVisitsSpy = jest
+          .spyOn(inPersonVisitsService, 'postSingleInPersonVisitRecord')
+          .mockReturnValueOnce(
+            Promise.resolve(new NestedInPersonVisitsEntity(data)),
+          );
+
+        const result = await service.postSingleCaseInPersonVisitRecord(
+          body,
+          idir,
+          idPathParams,
+        );
+        expect(InPersonVisitsSpy).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(new NestedInPersonVisitsEntity(data));
       },
     );
   });

--- a/src/controllers/cases/cases.service.ts
+++ b/src/controllers/cases/cases.service.ts
@@ -17,7 +17,18 @@ import {
   AttachmentsEntity,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
-import { casesAttachmentsFieldName } from '../../common/constants/parameter-constants';
+import {
+  casesAttachmentsFieldName,
+  idName,
+} from '../../common/constants/parameter-constants';
+import {
+  PostInPersonVisitDto,
+  PostInPersonVisitDtoUpstream,
+} from '../../dto/post-in-person-visit.dto';
+import {
+  childVisitEntityIdFieldName,
+  childVisitIdirFieldName,
+} from '../../common/constants/upstream-constants';
 
 @Injectable()
 export class CasesService {
@@ -46,6 +57,22 @@ export class CasesService {
       RecordType.Case,
       id,
       since,
+    );
+  }
+
+  async postSingleCaseInPersonVisitRecord(
+    inPersonVisitsDto: PostInPersonVisitDto,
+    idir: string,
+    id: IdPathParams,
+  ): Promise<NestedInPersonVisitsEntity> {
+    const body = new PostInPersonVisitDtoUpstream({
+      ...inPersonVisitsDto,
+      [childVisitIdirFieldName]: idir,
+      [childVisitEntityIdFieldName]: id[idName],
+    });
+    return await this.inPersonVisitsService.postSingleInPersonVisitRecord(
+      RecordType.Case,
+      body,
     );
   }
 

--- a/src/controllers/service-requests/service-requests.controller.spec.ts
+++ b/src/controllers/service-requests/service-requests.controller.spec.ts
@@ -20,6 +20,7 @@ import {
   AttachmentsEntity,
   AttachmentsSingleResponseSRExample,
 } from '../../entities/attachments.entity';
+import { AuthService } from '../../common/guards/auth/auth.service';
 
 describe('ServiceRequestsController', () => {
   let controller: ServiceRequestsController;
@@ -30,6 +31,7 @@ describe('ServiceRequestsController', () => {
       imports: [ConfigModule.forRoot()],
       providers: [
         ServiceRequestsService,
+        AuthService,
         SupportNetworkService,
         AttachmentsService,
         TokenRefresherService,

--- a/src/controllers/service-requests/service-requests.controller.ts
+++ b/src/controllers/service-requests/service-requests.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Param,
   Query,
+  UseGuards,
   UseInterceptors,
   ValidationPipe,
 } from '@nestjs/common';
@@ -37,8 +38,10 @@ import {
   AttachmentsSingleResponseSRExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
+import { AuthGuard } from '../../common/guards/auth/auth.guard';
 
 @Controller('sr')
+@UseGuards(AuthGuard)
 @ApiNotFoundResponse({ type: ApiNotFoundEntity })
 @ApiInternalServerErrorResponse({ type: ApiInternalServerErrorEntity })
 export class ServiceRequestsController {

--- a/src/dto/post-in-person-visit.dto.spec.ts
+++ b/src/dto/post-in-person-visit.dto.spec.ts
@@ -1,0 +1,24 @@
+import { plainToInstance } from 'class-transformer';
+import { PostInPersonVisitDto } from './post-in-person-visit.dto';
+import { VisitDetails } from '../common/constants/enumerations';
+
+describe('PostInPersonVisitDto transform tests', () => {
+  it.each([
+    ['2024-10-24T22:16:24+0000', '10/24/2024 22:16:24'],
+    ['2020-12-31', '12/31/2020 00:00:00'],
+  ])(
+    `should transform the date when given good, past ISO-8601 input`,
+    (date, expected) => {
+      const postInPersonVisit = {
+        'Date of visit': date,
+        'Visit Description': 'comment',
+        'Visit Details Value': VisitDetails.ExemptionVisitOther,
+      };
+      const postInPersonVisitDto = plainToInstance(
+        PostInPersonVisitDto,
+        postInPersonVisit,
+      );
+      expect(postInPersonVisitDto['Date of visit']).toBe(expected);
+    },
+  );
+});

--- a/src/dto/post-in-person-visit.dto.ts
+++ b/src/dto/post-in-person-visit.dto.ts
@@ -1,0 +1,65 @@
+import { Expose, Transform } from 'class-transformer';
+import { isPastISO8601Date } from '../helpers/utilities/utilities.service';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty } from 'class-validator';
+import { VisitDetails } from '../common/constants/enumerations';
+import {
+  childVisitEntityIdFieldName,
+  childVisitIdirFieldName,
+  childVisitType,
+} from '../common/constants/upstream-constants';
+
+export class PostInPersonVisitDto {
+  @Transform(({ value }) => {
+    return isPastISO8601Date(value);
+  })
+  @IsNotEmpty()
+  @Expose()
+  @ApiProperty({
+    example: '2024-10-28T19:34:54',
+    format: 'date-time',
+    description:
+      'The ISO8601 formatted date of the visit, expected to be provided in UTC. Must not be a future date or time.',
+  })
+  'Date of visit': string;
+
+  // TODO: limit string length once given info about limits
+  @IsNotEmpty()
+  @Expose()
+  @ApiProperty({
+    example: 'Comments here',
+    description: 'Visit comments',
+  })
+  'Visit Description': string;
+
+  @IsEnum(VisitDetails)
+  @Expose()
+  @ApiProperty({
+    example: VisitDetails.PrivateVisitInHome,
+    description: 'The visit type',
+    enum: VisitDetails,
+  })
+  'Visit Details Value': string;
+}
+
+// TODO: see if Type is a const. If not, add here.
+
+// For use upstream only. Validation not done on parameters here
+// as it should have already been done previously
+export class PostInPersonVisitDtoUpstream {
+  'Date of visit': string;
+
+  [childVisitIdirFieldName]: string;
+
+  [childVisitEntityIdFieldName]: string;
+
+  'Type': string = childVisitType;
+
+  'Visit Description': string;
+
+  'Visit Details Value': string;
+
+  constructor(object) {
+    Object.assign(this, object);
+  }
+}

--- a/src/entities/attachments.entity.ts
+++ b/src/entities/attachments.entity.ts
@@ -302,13 +302,13 @@ export class AttachmentsEntity {
   FileSrcType: string;
 
   @ApiProperty({
-    example: AttachmentsSingleResponseCaseExample['  UpdatedByName'],
+    example: AttachmentsSingleResponseCaseExample['UpdatedByName'],
   })
   @Expose()
   UpdatedByName: string;
 
   @ApiProperty({
-    example: AttachmentsSingleResponseCaseExample['  FileName'],
+    example: AttachmentsSingleResponseCaseExample['FileName'],
   })
   @Expose()
   FileName: string;
@@ -320,7 +320,7 @@ export class AttachmentsEntity {
   'Memo Id': string;
 
   @ApiProperty({
-    example: AttachmentsSingleResponseCaseExample['  MemoNumber'],
+    example: AttachmentsSingleResponseCaseExample['MemoNumber'],
   })
   @Expose()
   MemoNumber: string;
@@ -338,7 +338,7 @@ export class AttachmentsEntity {
   'Attachment Id': string;
 
   @ApiProperty({
-    example: AttachmentsSingleResponseCaseExample['  Id'],
+    example: AttachmentsSingleResponseCaseExample['Id'],
   })
   @Expose()
   Id: string;

--- a/src/entities/in-person-visits.entity.ts
+++ b/src/entities/in-person-visits.entity.ts
@@ -25,6 +25,15 @@ export const InPersonVisitsListResponseCaseExample = {
   ],
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const { Name, ...PostInnerBody } = InPersonVisitsSingleResponseCaseExample;
+
+export const PostInPersonVisitResponseExample = {
+  items: {
+    ...PostInnerBody,
+  },
+};
+
 /*
  * Model definitions
  */
@@ -33,6 +42,7 @@ export const InPersonVisitsListResponseCaseExample = {
 export class InPersonVisitsEntity {
   @ApiProperty({
     example: InPersonVisitsSingleResponseCaseExample['Name'],
+    required: false,
   })
   @Expose()
   Name: string;

--- a/src/helpers/in-person-visits/in-person-visits.service.spec.ts
+++ b/src/helpers/in-person-visits/in-person-visits.service.spec.ts
@@ -8,15 +8,17 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { HttpService } from '@nestjs/axios';
 import { AxiosResponse } from 'axios';
 import { IdPathParams } from '../../dto/id-path-params.dto';
-import { RecordType } from '../../common/constants/enumerations';
+import { RecordType, VisitDetails } from '../../common/constants/enumerations';
 import { SinceQueryParams } from '../../dto/since-query-params.dto';
 import {
   InPersonVisitsEntity,
   InPersonVisitsListResponseCaseExample,
   InPersonVisitsSingleResponseCaseExample,
   NestedInPersonVisitsEntity,
+  PostInPersonVisitResponseExample,
 } from '../../entities/in-person-visits.entity';
 import { idName } from '../../common/constants/parameter-constants';
+import { PostInPersonVisitDtoUpstream } from '../../dto/post-in-person-visit.dto';
 
 describe('InPersonVisitsService', () => {
   let service: InPersonVisitsService;
@@ -111,6 +113,39 @@ describe('InPersonVisitsService', () => {
           recordType,
           idPathParams,
           sinceQueryParams,
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(new NestedInPersonVisitsEntity(data));
+      },
+    );
+  });
+
+  describe('postSingleInPersonVisitRecord tests', () => {
+    it.each([
+      [
+        PostInPersonVisitResponseExample,
+        RecordType.Case,
+        new PostInPersonVisitDtoUpstream({
+          'Date of visit': '11/08/2024 08:24:11',
+          'Visit Details Value': VisitDetails.NotPrivateInHome,
+          'Visit Description': 'comment',
+        }),
+      ],
+    ])(
+      'should return post values given good input',
+      async (data, recordType, body) => {
+        const spy = jest
+          .spyOn(requestPreparerService, 'sendPostRequest')
+          .mockResolvedValueOnce({
+            data: data,
+            headers: {},
+            status: 200,
+            statusText: 'OK',
+          } as AxiosResponse<any, any>);
+
+        const result = await service.postSingleInPersonVisitRecord(
+          recordType,
+          body,
         );
         expect(spy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new NestedInPersonVisitsEntity(data));

--- a/src/helpers/in-person-visits/in-person-visits.service.ts
+++ b/src/helpers/in-person-visits/in-person-visits.service.ts
@@ -11,13 +11,20 @@ import {
 import {
   baseUrlEnvVarName,
   inPersonVisitsEndpointEnvVarName,
+  postInPersonVisitsEndpointEnvVarName,
 } from '../../common/constants/upstream-constants';
-import { idName } from '../../common/constants/parameter-constants';
+import {
+  CONTENT_TYPE,
+  idName,
+} from '../../common/constants/parameter-constants';
+import { PostInPersonVisitDtoUpstream } from 'src/dto/post-in-person-visit.dto';
 
 @Injectable()
 export class InPersonVisitsService {
   url: string;
+  postUrl: string;
   workspace: string | undefined;
+  postWorkspace: string | undefined;
   sinceFieldName: string | undefined;
   constructor(
     private readonly configService: ConfigService,
@@ -27,7 +34,14 @@ export class InPersonVisitsService {
       this.configService.get<string>(baseUrlEnvVarName) +
       this.configService.get<string>(inPersonVisitsEndpointEnvVarName)
     ).replace(/\s/g, '%20');
+    this.postUrl = (
+      this.configService.get<string>(baseUrlEnvVarName) +
+      this.configService.get<string>(postInPersonVisitsEndpointEnvVarName)
+    ).replace(/\s/g, '%20');
     this.workspace = this.configService.get('workspaces.inPersonVisits');
+    this.postWorkspace = this.configService.get(
+      'workspaces.postInPersonVisits',
+    );
     this.sinceFieldName = this.configService.get(
       'sinceFieldName.inPersonVisits',
     );
@@ -55,5 +69,27 @@ export class InPersonVisitsService {
       return new NestedInPersonVisitsEntity(response.data);
     }
     return new InPersonVisitsEntity(response.data);
+  }
+
+  async postSingleInPersonVisitRecord(
+    _type: RecordType,
+    body: PostInPersonVisitDtoUpstream,
+  ): Promise<NestedInPersonVisitsEntity> {
+    const headers = {
+      Accept: CONTENT_TYPE,
+      'Content-Type': CONTENT_TYPE,
+      'Accept-Encoding': '*',
+    };
+    const params = {};
+    if (this.postWorkspace !== undefined) {
+      params['workspace'] = this.postWorkspace;
+    }
+    const response = await this.requestPreparerService.sendPostRequest(
+      this.postUrl,
+      body,
+      headers,
+      params,
+    );
+    return new NestedInPersonVisitsEntity(response.data);
   }
 }

--- a/src/helpers/utilities/utilities.service.spec.ts
+++ b/src/helpers/utilities/utilities.service.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { UtilitiesService } from './utilities.service';
+import { UtilitiesService, isPastISO8601Date } from './utilities.service';
+import { DateTime } from 'luxon';
+import { BadRequestException } from '@nestjs/common';
 
 describe('UtilitiesService', () => {
   let service: UtilitiesService;
@@ -32,6 +34,27 @@ describe('UtilitiesService', () => {
       `should return undefined on unexpected date format`,
       (input) => {
         expect(service.convertISODateToUpstreamFormat(input)).toBe(undefined);
+      },
+    );
+  });
+
+  describe('isPastISO8601Date tests', () => {
+    it.each([[DateTime.now().toUTC().minus(60000).toJSDate().toISOString()]])(
+      `should return a string upon being given a past ISO-8601 date`,
+      (input) => {
+        expect(typeof isPastISO8601Date(input)).toBe('string');
+      },
+    );
+
+    it.each([
+      [DateTime.now().toUTC().plus(600000).toJSDate().toISOString()],
+      ['abcdefgtlom'],
+    ])(
+      `should throw BadRequestException on future date or unexpected input format`,
+      (input) => {
+        expect(() => {
+          isPastISO8601Date(input);
+        }).toThrow(BadRequestException);
       },
     );
   });

--- a/src/helpers/utilities/utilities.service.ts
+++ b/src/helpers/utilities/utilities.service.ts
@@ -37,5 +37,7 @@ export function isPastISO8601Date(date: string): string {
       return dateObject.toFormat(upstreamDateFormat);
     }
   }
-  throw new BadRequestException('Date / time cannot be in the future');
+  throw new BadRequestException(
+    'Date / time must met the ISO-8601 standard, and cannot be in the future',
+  );
 }

--- a/src/helpers/utilities/utilities.service.ts
+++ b/src/helpers/utilities/utilities.service.ts
@@ -33,7 +33,7 @@ export function isPastISO8601Date(date: string): string {
       zone: 'UTC',
     });
     const currentTimeUTC = DateTime.now().toUTC();
-    if (dateObject < currentTimeUTC) {
+    if (dateObject <= currentTimeUTC) {
       return dateObject.toFormat(upstreamDateFormat);
     }
   }

--- a/src/helpers/utilities/utilities.service.ts
+++ b/src/helpers/utilities/utilities.service.ts
@@ -1,5 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { isISO8601 } from 'class-validator';
 import { DateTime } from 'luxon';
+import { upstreamDateFormat } from '../../common/constants/upstream-constants';
 
 @Injectable()
 export class UtilitiesService {
@@ -11,7 +13,7 @@ export class UtilitiesService {
   convertISODateToUpstreamFormat(isoDate: string): string | undefined {
     const upstreamDate = DateTime.fromISO(isoDate.trim(), {
       zone: 'UTC',
-    }).toFormat('MM/dd/yyyy HH:mm:ss');
+    }).toFormat(upstreamDateFormat);
     if (upstreamDate === 'Invalid DateTime') {
       return undefined;
     }
@@ -21,4 +23,19 @@ export class UtilitiesService {
   enumTypeGuard<T>(object: T, possibleValue: any): possibleValue is T[keyof T] {
     return Object.values(object).includes(possibleValue);
   }
+}
+
+// NOTE: This is outside of an injectable class because it is meant to be used in a DTO
+// context as a validator function
+export function isPastISO8601Date(date: string): string {
+  if (isISO8601(date, { strict: true })) {
+    const dateObject = DateTime.fromISO(date.trim(), {
+      zone: 'UTC',
+    });
+    const currentTimeUTC = DateTime.now().toUTC();
+    if (dateObject < currentTimeUTC) {
+      return dateObject.toFormat(upstreamDateFormat);
+    }
+  }
+  throw new BadRequestException('Date / time cannot be in the future');
 }


### PR DESCRIPTION
[Story link](https://bcsocialsector.service-now.com/now/nav/ui/classic/params/target/rm_story.do%3Fsys_id%3D56ef2d0a93191a10e09fb1584dba10e0%26sysparm_view%3Dscrum%26sysparm_record_target%3Drm_story%26sysparm_record_row%3D12%26sysparm_record_rows%3D21%26sysparm_record_list%3Depic%253Db96a9b1d931dd210e09fb1584dba1091%255EORDERBYnumber)

This PR adds the POST In person visits endpoint and associated unit tests.