### PR TITLE
GET List of Attachments configuration

### DIFF
--- a/src/common/constants/parameter-constants.ts
+++ b/src/common/constants/parameter-constants.ts
@@ -10,10 +10,10 @@ const idMaxLength = 100;
 const idRegex = /^[0-9\-A-Za-z]{1,100}$/;
 const idName = 'rowId';
 
-const casesAttachmentsFieldName = 'No Intervention';
-const incidentsAttachmentsFieldName = 'Incident No';
-const srAttachmentsFieldName = 'Application No';
-const memoAttachmentsFieldName = 'MemoNumber';
+const casesAttachmentsFieldName = 'Case Id';
+const incidentsAttachmentsFieldName = 'Incident Id';
+const srAttachmentsFieldName = 'SR Id';
+const memoAttachmentsFieldName = 'Memo Id';
 
 export {
   VIEW_MODE,

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -39,7 +39,7 @@ export default () => ({
   sinceFieldName: {
     supportNetwork: 'Updated',
     inPersonVisits: undefined,
-    attachments: undefined,
+    attachments: 'Last Updated Date',
   },
   skipAuthGuard: process.env.SKIP_AUTH_GUARD === 'true',
   endpointUrls: {

--- a/src/entities/attachments.entity.ts
+++ b/src/entities/attachments.entity.ts
@@ -4,64 +4,69 @@ import { Exclude, Expose, Type } from 'class-transformer';
 /*
  * Examples
  */
-// TODO: Replace 'string' with something meaningful when I can actually hit the endpoint
 const AttachmentsSingleResponseCaseExample = {
   'Application No': '',
-  Categorie: 'string',
-  Category: 'string',
-  'Client Flag': 'string',
-  'End Date': 'string',
-  'Final Flag': 'string',
-  'Form Description': 'string',
+  Categorie: 'Attachment',
+  Category: 'Assessment',
+  'Client Flag': 'N',
+  'End Date': '07/09/2024 00:00:00',
+  'Final Flag': 'Y',
+  'Form Description': 'Reportable Circumstance',
   'Incident Id': '',
   'Incident No': '',
-  Internal: 'string',
-  'Last Updated Date': 'string',
-  'No Intervention': 'Case-Id-Here',
-  'Portal Visible': 'string',
-  'Show on Contact': 'string',
-  Status: 'string',
-  'Sub-Category': 'string',
-  Template: 'string',
-  'Template Type': 'string',
-  'Case Id': 'string',
-  Comments: 'string',
-  'Created Date': 'string',
-  CreatedByName: 'string',
-  FileAutoUpdFlg: 'string',
-  FileDate: 'string',
-  FileDeferFlg: 'string',
-  FileDockReqFlg: 'string',
-  FileDockStatFlg: 'string',
-  FileExt: 'string',
-  FileSize: 'string',
-  FileSrcPath: 'string',
-  FileSrcType: 'string',
-  UpdatedByName: 'string',
-  FileName: 'string',
+  Internal: 'N',
+  'Last Updated Date': '07/09/2024 07:08:22',
+  'No Intervention': 'Numeric-Case-Id-Here',
+  'Portal Visible': 'No',
+  'Show on Contact': 'N',
+  Status: 'Complete',
+  'Sub-Category': 'Identification',
+  Template: 'CF0659',
+  'Template Type': 'Form',
+  'Case Id': 'Case-Id-Here',
+  Comments: 'comments here',
+  'Created Date': '07/09/2024 07:00:00',
+  CreatedByName: 'Creator-IDIR-Here',
+  FileAutoUpdFlg: 'Y',
+  FileDate: '07/09/2024 07:08:22',
+  FileDeferFlg: 'P',
+  FileDockReqFlg: 'N',
+  FileDockStatFlg: 'E',
+  FileExt: 'png',
+  FileSize: '16635',
+  FileSrcPath: 'file\\path\\here',
+  FileSrcType: 'FILE',
+  UpdatedByName: 'Updater-IDIR-Here',
+  FileName: 'File_Name_Here',
   'Memo Id': '',
   MemoNumber: '',
   'SR Id': '',
-  'Attachment Id': 'string',
-  Id: 'string',
+  'Attachment Id': 'Siebel Link Here',
+  Id: 'Attachment-Id-Here',
 };
 
 const AttachmentsSingleResponseIncidentExample = {
   ...AttachmentsSingleResponseCaseExample,
   'No Intervention': '',
-  'Incident No': 'Incident-Id-Here',
+  'Case Id': '',
+  'Incident Id': 'Incident-Id-Here',
+  'Incident No': 'Numeric-Incident-Id-Here',
 };
 
 const AttachmentsSingleResponseSRExample = {
   ...AttachmentsSingleResponseCaseExample,
   'No Intervention': '',
-  'Application No': 'SR-Id-Here',
+  'Case Id': '',
+  'Application No': 'Numeric-SR-Id-Here',
+  'SR Id': 'SR-Id-Here',
 };
 
 const AttachmentsSingleResponseMemoExample = {
   ...AttachmentsSingleResponseCaseExample,
   'No Intervention': '',
-  MemoNumber: 'Memo-Id-Here',
+  'Case Id': '',
+  MemoNumber: 'Numeric-Memo-Id-Here',
+  'Memo Id': 'Memo-Id-Here',
 };
 
 export const AttachmentsListResponseCaseExample = {
@@ -69,7 +74,8 @@ export const AttachmentsListResponseCaseExample = {
     AttachmentsSingleResponseCaseExample,
     {
       ...AttachmentsSingleResponseCaseExample,
-      'No Intervention': 'Another-Case-Id-Here',
+      'No Intervention': 'Another-Numeric-Case-Id-Here',
+      'Case Id': 'Another-Case-Id-Here',
     },
   ],
 };
@@ -79,7 +85,8 @@ export const AttachmentsListResponseIncidentExample = {
     AttachmentsSingleResponseIncidentExample,
     {
       ...AttachmentsSingleResponseIncidentExample,
-      'Incident No': 'Another-Incident-Id-Here',
+      'Incident No': 'Another-Numeric-Incident-Id-Here',
+      'Incident Id': 'Another-Incident-Id-Here',
     },
   ],
 };
@@ -89,7 +96,8 @@ export const AttachmentsListResponseSRExample = {
     AttachmentsSingleResponseSRExample,
     {
       ...AttachmentsSingleResponseSRExample,
-      'Application No': 'Another-SR-Id-Here',
+      'Application No': 'Another-Numeric-SR-Id-Here',
+      'SR Id': 'Another-SR-Id-Here',
     },
   ],
 };
@@ -99,7 +107,8 @@ export const AttachmentsListResponseMemoExample = {
     AttachmentsSingleResponseMemoExample,
     {
       ...AttachmentsSingleResponseMemoExample,
-      MemoNumber: 'Another-Memo-Id-Here',
+      MemoNumber: 'Another-Numeric-Memo-Id-Here',
+      'Memo Id': 'Another-Memo-Id-Here',
     },
   ],
 };
@@ -124,12 +133,14 @@ class AttachmentsEntity {
 
   @ApiProperty({
     example: AttachmentsSingleResponseCaseExample['Categorie'],
+    // "Service Request", "Attachment", "HLS Case"
   })
   @Expose()
   Categorie: string;
 
   @ApiProperty({
     example: AttachmentsSingleResponseCaseExample['Category'],
+    // "Assessment", "Vineland", "Identification"
   })
   @Expose()
   Category: string;
@@ -202,23 +213,27 @@ class AttachmentsEntity {
 
   @ApiProperty({
     example: AttachmentsSingleResponseCaseExample['Status'],
+    // "Open", "Profiled", "Complete"
   })
   @Expose()
   Status: string;
   @ApiProperty({
     example: AttachmentsSingleResponseCaseExample['Sub-Category'],
+    // "Resume", "Identification", "Language", "Legal/Court Documents", "Program Eligibility"
   })
   @Expose()
   'Sub-Category': string;
 
   @ApiProperty({
     example: AttachmentsSingleResponseCaseExample['Template'],
+    // "CF0659"
   })
   @Expose()
   Template: string;
 
   @ApiProperty({
     example: AttachmentsSingleResponseCaseExample['Template Type'],
+    // "Form", "Document"
   })
   @Expose()
   'Template Type': string;
@@ -297,6 +312,7 @@ class AttachmentsEntity {
 
   @ApiProperty({
     example: AttachmentsSingleResponseCaseExample['FileSrcType'],
+    // "FILE"
   })
   @Expose()
   FileSrcType: string;


### PR DESCRIPTION
[Story link](https://bcsocialsector.service-now.com/now/nav/ui/classic/params/target/rm_story.do%3Fsys_id%3D3504413d93199610e09fb1584dba1010%26sysparm_view%3Dscrum%26sysparm_record_target%3Drm_story%26sysparm_record_row%3D17%26sysparm_record_rows%3D34%26sysparm_record_list%3Depic%253Db96a9b1d931dd210e09fb1584dba1091%255EORDERBYnumber)

This PR adds configuration and swagger updates for the GET List of Attachments endpoint. Note that there is a bug on the Siebel side that is currently causing some queries to fail, so this may still occasionally throw errors unexpectedly.