### PR TITLE
GET Attachment Details (download attachment)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2022,6 +2022,12 @@
         }
       }
     },
+    "node_modules/@nestjs/core/node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "license": "MIT"
+    },
     "node_modules/@nestjs/mapped-types": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
@@ -2180,6 +2186,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@nestjs/swagger/node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "license": "MIT"
     },
     "node_modules/@nestjs/testing": {
       "version": "10.4.5",
@@ -7688,12 +7700,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/path-to-regexp": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
-      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
-      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
-	"test:gh": "jest --ci --reporters=default --reporters=jest-junit",
+    "test:gh": "jest --ci --reporters=default --reporters=jest-junit",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
@@ -81,19 +81,19 @@
       "**/*.(t|j)s",
       "!**/*.module.(t|j)s",
       "!**/main.ts",
-	  "!**/*.entity.(t|j)s",
-	  "!**/configuration.(t|j)s"
+      "!**/*.entity.(t|j)s",
+      "!**/configuration.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
   },
   "jest-junit": {
-	"outputDirectory": "reports",
-	"outputName": "jest-junit.xml",
-	"ancestorSeparator": " › ",
-	"uniqueOutputName": "false",
-	"suiteNameTemplate": "{title}",
-	"classNameTemplate": "{title}",
-	"titleTemplate": "{title}"
+    "outputDirectory": "reports",
+    "outputName": "jest-junit.xml",
+    "ancestorSeparator": " › ",
+    "uniqueOutputName": "false",
+    "suiteNameTemplate": "{title}",
+    "classNameTemplate": "{title}",
+    "titleTemplate": "{title}"
   }
 }

--- a/src/common/constants/parameter-constants.ts
+++ b/src/common/constants/parameter-constants.ts
@@ -2,13 +2,16 @@ const VIEW_MODE = 'Catalog';
 const CHILD_LINKS = 'None';
 const CONTENT_TYPE = 'application/json';
 const UNIFORM_RESPONSE = 'y';
+const INLINE_ATTACHMENT = 'true';
 const uniformResponseParamName = 'uniformresponse';
 const recordCountHeaderName = 'total-record-count';
+const inlineAttachmentParamName = 'inlineattachment';
 const sinceParamName = 'since';
 
 const idMaxLength = 100;
 const idRegex = /^[0-9\-A-Za-z]{1,100}$/;
 const idName = 'rowId';
+const attachmentIdName = 'attachmentId';
 
 const casesAttachmentsFieldName = 'Case Id';
 const incidentsAttachmentsFieldName = 'Incident Id';
@@ -20,12 +23,15 @@ export {
   CHILD_LINKS,
   CONTENT_TYPE,
   UNIFORM_RESPONSE,
+  INLINE_ATTACHMENT,
   uniformResponseParamName,
   recordCountHeaderName,
+  inlineAttachmentParamName,
   sinceParamName,
   idMaxLength,
   idRegex,
   idName,
+  attachmentIdName,
   casesAttachmentsFieldName,
   incidentsAttachmentsFieldName,
   srAttachmentsFieldName,

--- a/src/common/constants/parameter-constants.ts
+++ b/src/common/constants/parameter-constants.ts
@@ -9,6 +9,7 @@ const inlineAttachmentParamName = 'inlineattachment';
 const sinceParamName = 'since';
 
 const idMaxLength = 100;
+const versionRegexString = 'v:version(\\d+)';
 const idRegex = /^[0-9\-A-Za-z]{1,100}$/;
 const idName = 'rowId';
 const attachmentIdName = 'attachmentId';
@@ -29,6 +30,7 @@ export {
   inlineAttachmentParamName,
   sinceParamName,
   idMaxLength,
+  versionRegexString,
   idRegex,
   idName,
   attachmentIdName,

--- a/src/common/constants/swagger-constants.ts
+++ b/src/common/constants/swagger-constants.ts
@@ -13,13 +13,16 @@ const noContentResponseSwagger = {
   description: 'Empty body. Returned when no records match the given criteria.',
 };
 
-const headerInfo = [
-  {
-    name: 'version',
-    description: 'API version number.',
-    schema: { type: 'integer', default: 2, example: 2 },
-    required: true,
-  },
-];
+const versionInfo = {
+  name: 'version',
+  type: 'integer',
+  description: 'API version number.',
+  example: 2,
+  required: true,
+};
 
-export { totalRecordCountHeadersSwagger, noContentResponseSwagger, headerInfo };
+export {
+  totalRecordCountHeadersSwagger,
+  noContentResponseSwagger,
+  versionInfo,
+};

--- a/src/controllers/cases/cases.controller.spec.ts
+++ b/src/controllers/cases/cases.controller.spec.ts
@@ -9,7 +9,10 @@ import {
   SupportNetworkListResponseCaseExample,
 } from '../../entities/support-network.entity';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { AuthService } from '../../common/guards/auth/auth.service';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { SupportNetworkService } from '../../helpers/support-network/support-network.service';
@@ -22,11 +25,14 @@ import {
   PostInPersonVisitResponseExample,
 } from '../../entities/in-person-visits.entity';
 import {
+  attachmentIdName,
   idName,
   sinceParamName,
 } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import {
+  AttachmentDetailsCaseExample,
+  AttachmentDetailsEntity,
   AttachmentsListResponseCaseExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
@@ -208,6 +214,43 @@ describe('CasesController', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleCaseAttachmentDetailsRecord tests', () => {
+    it.each([
+      [
+        AttachmentDetailsCaseExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        {
+          [sinceParamName]: '2020-02-02',
+          [startRowNumParamName]: 0,
+        } as FilterQueryParams,
+      ],
+    ])(
+      'should return nested values given good input',
+      async (data, idPathParams, filterQueryParams) => {
+        const caseServiceSpy = jest
+          .spyOn(casesService, 'getSingleCaseAttachmentDetailsRecord')
+          .mockReturnValueOnce(
+            Promise.resolve(new AttachmentDetailsEntity(data)),
+          );
+
+        const result = await controller.getSingleCaseAttachmentDetailsRecord(
+          idPathParams,
+          res,
+          filterQueryParams,
+        );
+        expect(caseServiceSpy).toHaveBeenCalledWith(
+          idPathParams,
+          res,
+          filterQueryParams,
+        );
+        expect(result).toEqual(new AttachmentDetailsEntity(data));
       },
     );
   });

--- a/src/controllers/cases/cases.controller.ts
+++ b/src/controllers/cases/cases.controller.ts
@@ -31,9 +31,13 @@ import {
   NestedSupportNetworkEntity,
   SupportNetworkListResponseCaseExample,
 } from '../../entities/support-network.entity';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import {
+  attachmentIdName,
   CONTENT_TYPE,
   idName,
   sinceParamName,
@@ -46,6 +50,8 @@ import {
   PostInPersonVisitResponseExample,
 } from '../../entities/in-person-visits.entity';
 import {
+  AttachmentDetailsCaseExample,
+  AttachmentDetailsEntity,
   AttachmentsListResponseCaseExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
@@ -279,6 +285,60 @@ export class CasesController {
     filter?: FilterQueryParams,
   ): Promise<NestedAttachmentsEntity> {
     return await this.casesService.getSingleCaseAttachmentRecord(
+      id,
+      res,
+      filter,
+    );
+  }
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Get(`:${idName}/attachments/:${attachmentIdName}`)
+  @ApiOperation({
+    description:
+      'Download an Attachment related to a given Case Id by its Attachment Id.',
+  })
+  @ApiQuery({ name: sinceParamName, required: false })
+  @ApiQuery({ name: recordCountNeededParamName, required: false })
+  @ApiQuery({ name: pageSizeParamName, required: false })
+  @ApiQuery({ name: startRowNumParamName, required: false })
+  @ApiExtraModels(AttachmentDetailsEntity)
+  @ApiNoContentResponse(noContentResponseSwagger)
+  @ApiOkResponse({
+    headers: totalRecordCountHeadersSwagger,
+    content: {
+      [CONTENT_TYPE]: {
+        schema: {
+          $ref: getSchemaPath(AttachmentDetailsEntity),
+        },
+        examples: {
+          AttachmentDetailsResponse: {
+            value: AttachmentDetailsCaseExample,
+          },
+        },
+      },
+    },
+  })
+  async getSingleCaseAttachmentDetailsRecord(
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: AttachmentIdPathParams,
+    @Res({ passthrough: true }) res: Response,
+    @Query(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+        skipMissingProperties: true,
+      }),
+    )
+    filter?: FilterQueryParams,
+  ): Promise<AttachmentDetailsEntity> {
+    return await this.casesService.getSingleCaseAttachmentDetailsRecord(
       id,
       res,
       filter,

--- a/src/controllers/cases/cases.controller.ts
+++ b/src/controllers/cases/cases.controller.ts
@@ -20,6 +20,7 @@ import {
   ApiHeaders,
   ApiInternalServerErrorResponse,
   ApiNoContentResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiQuery,
@@ -75,12 +76,14 @@ import {
 import { ApiForbiddenErrorEntity } from '../../entities/api-forbidden-error.entity';
 import { ApiUnauthorizedErrorEntity } from '../../entities/api-unauthorized-error.entity';
 import { ApiBadRequestErrorEntity } from '../../entities/api-bad-request-error.entity';
+import { ApiNotFoundErrorEntity } from '../../entities/api-not-found-error.entity';
 
 @Controller('case')
 @UseGuards(AuthGuard)
 @ApiBadRequestResponse({ type: ApiBadRequestErrorEntity })
 @ApiUnauthorizedResponse({ type: ApiUnauthorizedErrorEntity })
 @ApiForbiddenResponse({ type: ApiForbiddenErrorEntity })
+@ApiNotFoundResponse({ type: ApiNotFoundErrorEntity })
 @ApiInternalServerErrorResponse({ type: ApiInternalServerErrorEntity })
 @ApiHeaders(headerInfo)
 export class CasesController {

--- a/src/controllers/cases/cases.controller.ts
+++ b/src/controllers/cases/cases.controller.ts
@@ -17,12 +17,12 @@ import {
   ApiCreatedResponse,
   ApiExtraModels,
   ApiForbiddenResponse,
-  ApiHeaders,
   ApiInternalServerErrorResponse,
   ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiUnauthorizedResponse,
   getSchemaPath,
@@ -65,9 +65,9 @@ import {
 } from '../../common/constants/upstream-constants';
 import { Request, Response } from 'express';
 import {
-  headerInfo,
   noContentResponseSwagger,
   totalRecordCountHeadersSwagger,
+  versionInfo,
 } from '../../common/constants/swagger-constants';
 import {
   NestedContactsEntity,
@@ -85,7 +85,7 @@ import { ApiNotFoundErrorEntity } from '../../entities/api-not-found-error.entit
 @ApiForbiddenResponse({ type: ApiForbiddenErrorEntity })
 @ApiNotFoundResponse({ type: ApiNotFoundErrorEntity })
 @ApiInternalServerErrorResponse({ type: ApiInternalServerErrorEntity })
-@ApiHeaders(headerInfo)
+@ApiParam(versionInfo)
 export class CasesController {
   constructor(private readonly casesService: CasesService) {}
 

--- a/src/controllers/cases/cases.service.spec.ts
+++ b/src/controllers/cases/cases.service.spec.ts
@@ -9,7 +9,10 @@ import {
   NestedSupportNetworkEntity,
   SupportNetworkListResponseCaseExample,
 } from '../../entities/support-network.entity';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { RecordType, VisitDetails } from '../../common/constants/enumerations';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
@@ -21,12 +24,15 @@ import {
   PostInPersonVisitResponseExample,
 } from '../../entities/in-person-visits.entity';
 import {
+  attachmentIdName,
   casesAttachmentsFieldName,
   idName,
   sinceParamName,
 } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import {
+  AttachmentDetailsCaseExample,
+  AttachmentDetailsEntity,
   AttachmentsListResponseCaseExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
@@ -218,6 +224,43 @@ describe('CasesService', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleCaseAttachmentDetailsRecord tests', () => {
+    it.each([
+      [
+        AttachmentDetailsCaseExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        { [sinceParamName]: '2024-12-01' } as FilterQueryParams,
+        casesAttachmentsFieldName,
+      ],
+    ])(
+      'should return nested values given good input',
+      async (data, idPathParams, filterQueryParams, typeFieldName) => {
+        const attachmentsSpy = jest
+          .spyOn(attachmentsService, 'getSingleAttachmentDetailsRecord')
+          .mockReturnValueOnce(
+            Promise.resolve(new AttachmentDetailsEntity(data)),
+          );
+
+        const result = await service.getSingleCaseAttachmentDetailsRecord(
+          idPathParams,
+          res,
+          filterQueryParams,
+        );
+        expect(attachmentsSpy).toHaveBeenCalledWith(
+          RecordType.Case,
+          idPathParams,
+          typeFieldName,
+          res,
+          filterQueryParams,
+        );
+        expect(result).toEqual(new AttachmentDetailsEntity(data));
       },
     );
   });

--- a/src/controllers/cases/cases.service.ts
+++ b/src/controllers/cases/cases.service.ts
@@ -2,12 +2,18 @@ import { Injectable } from '@nestjs/common';
 import { SupportNetworkService } from '../../helpers/support-network/support-network.service';
 import { RecordType } from '../../common/constants/enumerations';
 import { NestedSupportNetworkEntity } from '../../entities/support-network.entity';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { InPersonVisitsService } from '../../helpers/in-person-visits/in-person-visits.service';
 import { NestedInPersonVisitsEntity } from '../../entities/in-person-visits.entity';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
-import { NestedAttachmentsEntity } from '../../entities/attachments.entity';
+import {
+  AttachmentDetailsEntity,
+  NestedAttachmentsEntity,
+} from '../../entities/attachments.entity';
 import {
   casesAttachmentsFieldName,
   idName,
@@ -81,6 +87,20 @@ export class CasesService {
     filter?: FilterQueryParams,
   ): Promise<NestedAttachmentsEntity> {
     return await this.attachmentsService.getSingleAttachmentRecord(
+      RecordType.Case,
+      id,
+      casesAttachmentsFieldName,
+      res,
+      filter,
+    );
+  }
+
+  async getSingleCaseAttachmentDetailsRecord(
+    id: AttachmentIdPathParams,
+    res: Response,
+    filter?: FilterQueryParams,
+  ): Promise<AttachmentDetailsEntity> {
+    return await this.attachmentsService.getSingleAttachmentDetailsRecord(
       RecordType.Case,
       id,
       casesAttachmentsFieldName,

--- a/src/controllers/incidents/incidents.controller.spec.ts
+++ b/src/controllers/incidents/incidents.controller.spec.ts
@@ -9,18 +9,24 @@ import {
   SupportNetworkListResponseIncidentExample,
 } from '../../entities/support-network.entity';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { AuthService } from '../../common/guards/auth/auth.service';
 import { SupportNetworkService } from '../../helpers/support-network/support-network.service';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import {
+  attachmentIdName,
   idName,
   sinceParamName,
 } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import {
+  AttachmentDetailsEntity,
+  AttachmentDetailsIncidentExample,
   AttachmentsListResponseIncidentExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
@@ -134,6 +140,44 @@ describe('IncidentsController', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleIncidentAttachmentDetailsRecord tests', () => {
+    it.each([
+      [
+        AttachmentDetailsIncidentExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        {
+          [sinceParamName]: '2020-02-02',
+          [startRowNumParamName]: 0,
+        } as FilterQueryParams,
+      ],
+    ])(
+      'should return nested values given good input',
+      async (data, idPathParams, filterQueryParams) => {
+        const incidentServiceSpy = jest
+          .spyOn(incidentsService, 'getSingleIncidentAttachmentDetailsRecord')
+          .mockReturnValueOnce(
+            Promise.resolve(new AttachmentDetailsEntity(data)),
+          );
+
+        const result =
+          await controller.getSingleIncidentAttachmentDetailsRecord(
+            idPathParams,
+            res,
+            filterQueryParams,
+          );
+        expect(incidentServiceSpy).toHaveBeenCalledWith(
+          idPathParams,
+          res,
+          filterQueryParams,
+        );
+        expect(result).toEqual(new AttachmentDetailsEntity(data));
       },
     );
   });

--- a/src/controllers/incidents/incidents.controller.ts
+++ b/src/controllers/incidents/incidents.controller.ts
@@ -28,9 +28,13 @@ import {
   NestedSupportNetworkEntity,
   SupportNetworkListResponseIncidentExample,
 } from '../../entities/support-network.entity';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import {
+  attachmentIdName,
   CONTENT_TYPE,
   idName,
   sinceParamName,
@@ -40,6 +44,8 @@ import { AuthGuard } from '../../common/guards/auth/auth.guard';
 import {
   NestedAttachmentsEntity,
   AttachmentsListResponseIncidentExample,
+  AttachmentDetailsEntity,
+  AttachmentDetailsIncidentExample,
 } from '../../entities/attachments.entity';
 import { Response } from 'express';
 import {
@@ -172,6 +178,59 @@ export class IncidentsController {
     filter?: FilterQueryParams,
   ): Promise<NestedAttachmentsEntity> {
     return await this.incidentsService.getSingleIncidentAttachmentRecord(
+      id,
+      res,
+      filter,
+    );
+  }
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Get(`:${idName}/attachments/:${attachmentIdName}`)
+  @ApiOperation({
+    description:
+      'Download an Attachment related to a given Incident Id by its Attachment Id.',
+  })
+  @ApiQuery({ name: sinceParamName, required: false })
+  @ApiQuery({ name: recordCountNeededParamName, required: false })
+  @ApiQuery({ name: pageSizeParamName, required: false })
+  @ApiQuery({ name: startRowNumParamName, required: false })
+  @ApiExtraModels(AttachmentDetailsEntity)
+  @ApiOkResponse({
+    headers: totalRecordCountHeadersSwagger,
+    content: {
+      [CONTENT_TYPE]: {
+        schema: {
+          $ref: getSchemaPath(AttachmentDetailsEntity),
+        },
+        examples: {
+          AttachmentDetailsResponse: {
+            value: AttachmentDetailsIncidentExample,
+          },
+        },
+      },
+    },
+  })
+  async getSingleIncidentAttachmentDetailsRecord(
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: AttachmentIdPathParams,
+    @Res({ passthrough: true }) res: Response,
+    @Query(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+        skipMissingProperties: true,
+      }),
+    )
+    filter?: FilterQueryParams,
+  ): Promise<AttachmentDetailsEntity> {
+    return await this.incidentsService.getSingleIncidentAttachmentDetailsRecord(
       id,
       res,
       filter,

--- a/src/controllers/incidents/incidents.controller.ts
+++ b/src/controllers/incidents/incidents.controller.ts
@@ -13,12 +13,12 @@ import {
   ApiBadRequestResponse,
   ApiExtraModels,
   ApiForbiddenResponse,
-  ApiHeaders,
   ApiInternalServerErrorResponse,
   ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiUnauthorizedResponse,
   getSchemaPath,
@@ -50,9 +50,9 @@ import {
 } from '../../entities/attachments.entity';
 import { Response } from 'express';
 import {
-  headerInfo,
   noContentResponseSwagger,
   totalRecordCountHeadersSwagger,
+  versionInfo,
 } from '../../common/constants/swagger-constants';
 import {
   pageSizeParamName,
@@ -76,7 +76,7 @@ import { ApiNotFoundErrorEntity } from '../../entities/api-not-found-error.entit
 @ApiForbiddenResponse({ type: ApiForbiddenErrorEntity })
 @ApiNotFoundResponse({ type: ApiNotFoundErrorEntity })
 @ApiInternalServerErrorResponse({ type: ApiInternalServerErrorEntity })
-@ApiHeaders(headerInfo)
+@ApiParam(versionInfo)
 export class IncidentsController {
   constructor(private readonly incidentsService: IncidentsService) {}
 

--- a/src/controllers/incidents/incidents.controller.ts
+++ b/src/controllers/incidents/incidents.controller.ts
@@ -16,6 +16,7 @@ import {
   ApiHeaders,
   ApiInternalServerErrorResponse,
   ApiNoContentResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiQuery,
@@ -65,6 +66,7 @@ import {
 import { ApiUnauthorizedErrorEntity } from '../../entities/api-unauthorized-error.entity';
 import { ApiForbiddenErrorEntity } from '../../entities/api-forbidden-error.entity';
 import { ApiBadRequestErrorEntity } from '../../entities/api-bad-request-error.entity';
+import { ApiNotFoundErrorEntity } from '../../entities/api-not-found-error.entity';
 
 @Controller('incident')
 @UseGuards(AuthGuard)
@@ -72,6 +74,7 @@ import { ApiBadRequestErrorEntity } from '../../entities/api-bad-request-error.e
 @ApiBadRequestResponse({ type: ApiBadRequestErrorEntity })
 @ApiUnauthorizedResponse({ type: ApiUnauthorizedErrorEntity })
 @ApiForbiddenResponse({ type: ApiForbiddenErrorEntity })
+@ApiNotFoundResponse({ type: ApiNotFoundErrorEntity })
 @ApiInternalServerErrorResponse({ type: ApiInternalServerErrorEntity })
 @ApiHeaders(headerInfo)
 export class IncidentsController {

--- a/src/controllers/incidents/incidents.service.spec.ts
+++ b/src/controllers/incidents/incidents.service.spec.ts
@@ -10,17 +10,23 @@ import {
   SupportNetworkListResponseIncidentExample,
 } from '../../entities/support-network.entity';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { RecordType } from '../../common/constants/enumerations';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import {
+  attachmentIdName,
   idName,
   incidentsAttachmentsFieldName,
   sinceParamName,
 } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import {
+  AttachmentDetailsEntity,
+  AttachmentDetailsIncidentExample,
   AttachmentsListResponseIncidentExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
@@ -146,6 +152,43 @@ describe('IncidentsService', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleIncidentAttachmentDetailsRecord tests', () => {
+    it.each([
+      [
+        AttachmentDetailsIncidentExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        { [sinceParamName]: '2024-12-01' } as FilterQueryParams,
+        incidentsAttachmentsFieldName,
+      ],
+    ])(
+      'should return nested values given good input',
+      async (data, idPathParams, filterQueryParams, typeFieldName) => {
+        const attachmentsSpy = jest
+          .spyOn(attachmentsService, 'getSingleAttachmentDetailsRecord')
+          .mockReturnValueOnce(
+            Promise.resolve(new AttachmentDetailsEntity(data)),
+          );
+
+        const result = await service.getSingleIncidentAttachmentDetailsRecord(
+          idPathParams,
+          res,
+          filterQueryParams,
+        );
+        expect(attachmentsSpy).toHaveBeenCalledWith(
+          RecordType.Incident,
+          idPathParams,
+          typeFieldName,
+          res,
+          filterQueryParams,
+        );
+        expect(result).toEqual(new AttachmentDetailsEntity(data));
       },
     );
   });

--- a/src/controllers/incidents/incidents.service.ts
+++ b/src/controllers/incidents/incidents.service.ts
@@ -2,11 +2,17 @@ import { Injectable } from '@nestjs/common';
 import { SupportNetworkService } from '../../helpers/support-network/support-network.service';
 import { RecordType } from '../../common/constants/enumerations';
 import { NestedSupportNetworkEntity } from '../../entities/support-network.entity';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import { incidentsAttachmentsFieldName } from '../../common/constants/parameter-constants';
-import { NestedAttachmentsEntity } from '../../entities/attachments.entity';
+import {
+  AttachmentDetailsEntity,
+  NestedAttachmentsEntity,
+} from '../../entities/attachments.entity';
 import { Response } from 'express';
 import { NestedContactsEntity } from '../../entities/contacts.entity';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
@@ -38,6 +44,20 @@ export class IncidentsService {
     filter?: FilterQueryParams,
   ): Promise<NestedAttachmentsEntity> {
     return await this.attachmentsService.getSingleAttachmentRecord(
+      RecordType.Incident,
+      id,
+      incidentsAttachmentsFieldName,
+      res,
+      filter,
+    );
+  }
+
+  async getSingleIncidentAttachmentDetailsRecord(
+    id: AttachmentIdPathParams,
+    res: Response,
+    filter?: FilterQueryParams,
+  ): Promise<AttachmentDetailsEntity> {
+    return await this.attachmentsService.getSingleAttachmentDetailsRecord(
       RecordType.Incident,
       id,
       incidentsAttachmentsFieldName,

--- a/src/controllers/memos/memos.controller.spec.ts
+++ b/src/controllers/memos/memos.controller.spec.ts
@@ -9,12 +9,18 @@ import { AttachmentsService } from '../../helpers/attachments/attachments.servic
 import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import { MemosService } from './memos.service';
 import {
+  attachmentIdName,
   idName,
   sinceParamName,
 } from '../../common/constants/parameter-constants';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import {
+  AttachmentDetailsEntity,
+  AttachmentDetailsMemoExample,
   AttachmentsListResponseMemoExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
@@ -88,6 +94,43 @@ describe('MemosController', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleMemoAttachmentDetailsRecord tests', () => {
+    it.each([
+      [
+        AttachmentDetailsMemoExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        {
+          [sinceParamName]: '2020-02-02',
+          [startRowNumParamName]: 0,
+        } as FilterQueryParams,
+      ],
+    ])(
+      'should return nested values given good input',
+      async (data, idPathParams, filterQueryParams) => {
+        const memoServiceSpy = jest
+          .spyOn(memosService, 'getSingleMemoAttachmentDetailsRecord')
+          .mockReturnValueOnce(
+            Promise.resolve(new AttachmentDetailsEntity(data)),
+          );
+
+        const result = await controller.getSingleMemoAttachmentDetailsRecord(
+          idPathParams,
+          res,
+          filterQueryParams,
+        );
+        expect(memoServiceSpy).toHaveBeenCalledWith(
+          idPathParams,
+          res,
+          filterQueryParams,
+        );
+        expect(result).toEqual(new AttachmentDetailsEntity(data));
       },
     );
   });

--- a/src/controllers/memos/memos.controller.ts
+++ b/src/controllers/memos/memos.controller.ts
@@ -21,6 +21,7 @@ import {
   ApiForbiddenResponse,
   ApiUnauthorizedResponse,
   ApiBadRequestResponse,
+  ApiNotFoundResponse,
 } from '@nestjs/swagger';
 import {
   idName,
@@ -58,12 +59,14 @@ import {
 import { ApiForbiddenErrorEntity } from '../../entities/api-forbidden-error.entity';
 import { ApiUnauthorizedErrorEntity } from '../../entities/api-unauthorized-error.entity';
 import { ApiBadRequestErrorEntity } from '../../entities/api-bad-request-error.entity';
+import { ApiNotFoundErrorEntity } from '../../entities/api-not-found-error.entity';
 
 @Controller('memo')
 @ApiNoContentResponse(noContentResponseSwagger)
 @ApiBadRequestResponse({ type: ApiBadRequestErrorEntity })
 @ApiUnauthorizedResponse({ type: ApiUnauthorizedErrorEntity })
 @ApiForbiddenResponse({ type: ApiForbiddenErrorEntity })
+@ApiNotFoundResponse({ type: ApiNotFoundErrorEntity })
 @ApiInternalServerErrorResponse({ type: ApiInternalServerErrorEntity })
 @ApiHeaders(headerInfo)
 export class MemosController {

--- a/src/controllers/memos/memos.controller.ts
+++ b/src/controllers/memos/memos.controller.ts
@@ -17,11 +17,11 @@ import {
   getSchemaPath,
   ApiInternalServerErrorResponse,
   ApiNoContentResponse,
-  ApiHeaders,
   ApiForbiddenResponse,
   ApiUnauthorizedResponse,
   ApiBadRequestResponse,
   ApiNotFoundResponse,
+  ApiParam,
 } from '@nestjs/swagger';
 import {
   idName,
@@ -43,9 +43,9 @@ import {
 import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
 import { Response } from 'express';
 import {
-  headerInfo,
   noContentResponseSwagger,
   totalRecordCountHeadersSwagger,
+  versionInfo,
 } from '../../common/constants/swagger-constants';
 import {
   pageSizeParamName,
@@ -68,7 +68,7 @@ import { ApiNotFoundErrorEntity } from '../../entities/api-not-found-error.entit
 @ApiForbiddenResponse({ type: ApiForbiddenErrorEntity })
 @ApiNotFoundResponse({ type: ApiNotFoundErrorEntity })
 @ApiInternalServerErrorResponse({ type: ApiInternalServerErrorEntity })
-@ApiHeaders(headerInfo)
+@ApiParam(versionInfo)
 export class MemosController {
   constructor(private readonly memosService: MemosService) {}
 

--- a/src/controllers/memos/memos.controller.ts
+++ b/src/controllers/memos/memos.controller.ts
@@ -26,12 +26,18 @@ import {
   idName,
   CONTENT_TYPE,
   sinceParamName,
+  attachmentIdName,
 } from '../../common/constants/parameter-constants';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import {
   NestedAttachmentsEntity,
   AttachmentsListResponseMemoExample,
+  AttachmentDetailsEntity,
+  AttachmentDetailsMemoExample,
 } from '../../entities/attachments.entity';
 import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
 import { Response } from 'express';
@@ -110,6 +116,59 @@ export class MemosController {
     filter?: FilterQueryParams,
   ): Promise<NestedAttachmentsEntity> {
     return await this.memosService.getSingleMemoAttachmentRecord(
+      id,
+      res,
+      filter,
+    );
+  }
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Get(`:${idName}/attachments/:${attachmentIdName}`)
+  @ApiOperation({
+    description:
+      'Download an Attachment related to a given Memo Id by its Attachment Id.',
+  })
+  @ApiQuery({ name: sinceParamName, required: false })
+  @ApiQuery({ name: recordCountNeededParamName, required: false })
+  @ApiQuery({ name: pageSizeParamName, required: false })
+  @ApiQuery({ name: startRowNumParamName, required: false })
+  @ApiExtraModels(AttachmentDetailsEntity)
+  @ApiOkResponse({
+    headers: totalRecordCountHeadersSwagger,
+    content: {
+      [CONTENT_TYPE]: {
+        schema: {
+          $ref: getSchemaPath(AttachmentDetailsEntity),
+        },
+        examples: {
+          AttachmentDetailsResponse: {
+            value: AttachmentDetailsMemoExample,
+          },
+        },
+      },
+    },
+  })
+  async getSingleMemoAttachmentDetailsRecord(
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: AttachmentIdPathParams,
+    @Res({ passthrough: true }) res: Response,
+    @Query(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+        skipMissingProperties: true,
+      }),
+    )
+    filter?: FilterQueryParams,
+  ): Promise<AttachmentDetailsEntity> {
+    return await this.memosService.getSingleMemoAttachmentDetailsRecord(
       id,
       res,
       filter,

--- a/src/controllers/memos/memos.service.spec.ts
+++ b/src/controllers/memos/memos.service.spec.ts
@@ -8,16 +8,22 @@ import { TokenRefresherService } from '../../external-api/token-refresher/token-
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import {
+  AttachmentDetailsEntity,
+  AttachmentDetailsMemoExample,
   AttachmentsListResponseMemoExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import { RecordType } from '../../common/constants/enumerations';
 import {
+  attachmentIdName,
   idName,
   memoAttachmentsFieldName,
   sinceParamName,
 } from '../../common/constants/parameter-constants';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { getMockRes } from '@jest-mock/express';
 import { startRowNumParamName } from '../../common/constants/upstream-constants';
@@ -98,6 +104,43 @@ describe('MemosService', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
+      },
+    );
+  });
+
+  describe('getSinglememoAttachmentDetailsRecord tests', () => {
+    it.each([
+      [
+        AttachmentDetailsMemoExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        { [sinceParamName]: '2024-12-01' } as FilterQueryParams,
+        memoAttachmentsFieldName,
+      ],
+    ])(
+      'should return nested values given good input',
+      async (data, idPathParams, filterQueryParams, typeFieldName) => {
+        const attachmentsSpy = jest
+          .spyOn(attachmentsService, 'getSingleAttachmentDetailsRecord')
+          .mockReturnValueOnce(
+            Promise.resolve(new AttachmentDetailsEntity(data)),
+          );
+
+        const result = await service.getSingleMemoAttachmentDetailsRecord(
+          idPathParams,
+          res,
+          filterQueryParams,
+        );
+        expect(attachmentsSpy).toHaveBeenCalledWith(
+          RecordType.Memo,
+          idPathParams,
+          typeFieldName,
+          res,
+          filterQueryParams,
+        );
+        expect(result).toEqual(new AttachmentDetailsEntity(data));
       },
     );
   });

--- a/src/controllers/memos/memos.service.ts
+++ b/src/controllers/memos/memos.service.ts
@@ -1,9 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import { RecordType } from '../../common/constants/enumerations';
 import { memoAttachmentsFieldName } from '../../common/constants/parameter-constants';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
-import { NestedAttachmentsEntity } from '../../entities/attachments.entity';
+import {
+  AttachmentDetailsEntity,
+  NestedAttachmentsEntity,
+} from '../../entities/attachments.entity';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import { Response } from 'express';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
@@ -22,6 +28,20 @@ export class MemosService {
     filter?: FilterQueryParams,
   ): Promise<NestedAttachmentsEntity> {
     return await this.attachmentsService.getSingleAttachmentRecord(
+      RecordType.Memo,
+      id,
+      memoAttachmentsFieldName,
+      res,
+      filter,
+    );
+  }
+
+  async getSingleMemoAttachmentDetailsRecord(
+    id: AttachmentIdPathParams,
+    res: Response,
+    filter?: FilterQueryParams,
+  ): Promise<AttachmentDetailsEntity> {
+    return await this.attachmentsService.getSingleAttachmentDetailsRecord(
       RecordType.Memo,
       id,
       memoAttachmentsFieldName,

--- a/src/controllers/service-requests/service-requests.controller.spec.ts
+++ b/src/controllers/service-requests/service-requests.controller.spec.ts
@@ -8,18 +8,24 @@ import {
   NestedSupportNetworkEntity,
   SupportNetworkListResponseSRExample,
 } from '../../entities/support-network.entity';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { SupportNetworkService } from '../../helpers/support-network/support-network.service';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import {
+  attachmentIdName,
   idName,
   sinceParamName,
 } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import {
+  AttachmentDetailsEntity,
+  AttachmentDetailsSRExample,
   AttachmentsListResponseSRExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
@@ -138,6 +144,43 @@ describe('ServiceRequestsController', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleSRAttachmentDetailsRecord tests', () => {
+    it.each([
+      [
+        AttachmentDetailsSRExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        {
+          [sinceParamName]: '2020-02-02',
+          [startRowNumParamName]: 0,
+        } as FilterQueryParams,
+      ],
+    ])(
+      'should return nested values given good input',
+      async (data, idPathParams, filterQueryParams) => {
+        const SRsServiceSpy = jest
+          .spyOn(serviceRequestsService, 'getSingleSRAttachmentDetailsRecord')
+          .mockReturnValueOnce(
+            Promise.resolve(new AttachmentDetailsEntity(data)),
+          );
+
+        const result = await controller.getSingleSRAttachmentDetailsRecord(
+          idPathParams,
+          res,
+          filterQueryParams,
+        );
+        expect(SRsServiceSpy).toHaveBeenCalledWith(
+          idPathParams,
+          res,
+          filterQueryParams,
+        );
+        expect(result).toEqual(new AttachmentDetailsEntity(data));
       },
     );
   });

--- a/src/controllers/service-requests/service-requests.controller.ts
+++ b/src/controllers/service-requests/service-requests.controller.ts
@@ -17,11 +17,11 @@ import {
   ApiOperation,
   ApiInternalServerErrorResponse,
   ApiNoContentResponse,
-  ApiHeaders,
   ApiForbiddenResponse,
   ApiUnauthorizedResponse,
   ApiBadRequestResponse,
   ApiNotFoundResponse,
+  ApiParam,
 } from '@nestjs/swagger';
 import { ServiceRequestsService } from './service-requests.service';
 import {
@@ -49,9 +49,9 @@ import {
 import { AuthGuard } from '../../common/guards/auth/auth.guard';
 import { Response } from 'express';
 import {
-  headerInfo,
   noContentResponseSwagger,
   totalRecordCountHeadersSwagger,
+  versionInfo,
 } from '../../common/constants/swagger-constants';
 import {
   pageSizeParamName,
@@ -75,7 +75,7 @@ import { ApiNotFoundErrorEntity } from '../../entities/api-not-found-error.entit
 @ApiForbiddenResponse({ type: ApiForbiddenErrorEntity })
 @ApiNotFoundResponse({ type: ApiNotFoundErrorEntity })
 @ApiInternalServerErrorResponse({ type: ApiInternalServerErrorEntity })
-@ApiHeaders(headerInfo)
+@ApiParam(versionInfo)
 export class ServiceRequestsController {
   constructor(private readonly serviceRequestService: ServiceRequestsService) {}
 

--- a/src/controllers/service-requests/service-requests.controller.ts
+++ b/src/controllers/service-requests/service-requests.controller.ts
@@ -21,6 +21,7 @@ import {
   ApiForbiddenResponse,
   ApiUnauthorizedResponse,
   ApiBadRequestResponse,
+  ApiNotFoundResponse,
 } from '@nestjs/swagger';
 import { ServiceRequestsService } from './service-requests.service';
 import {
@@ -64,6 +65,7 @@ import {
 import { ApiForbiddenErrorEntity } from '../../entities/api-forbidden-error.entity';
 import { ApiUnauthorizedErrorEntity } from '../../entities/api-unauthorized-error.entity';
 import { ApiBadRequestErrorEntity } from '../../entities/api-bad-request-error.entity';
+import { ApiNotFoundErrorEntity } from '../../entities/api-not-found-error.entity';
 
 @Controller('sr')
 @UseGuards(AuthGuard)
@@ -71,6 +73,7 @@ import { ApiBadRequestErrorEntity } from '../../entities/api-bad-request-error.e
 @ApiBadRequestResponse({ type: ApiBadRequestErrorEntity })
 @ApiUnauthorizedResponse({ type: ApiUnauthorizedErrorEntity })
 @ApiForbiddenResponse({ type: ApiForbiddenErrorEntity })
+@ApiNotFoundResponse({ type: ApiNotFoundErrorEntity })
 @ApiInternalServerErrorResponse({ type: ApiInternalServerErrorEntity })
 @ApiHeaders(headerInfo)
 export class ServiceRequestsController {

--- a/src/controllers/service-requests/service-requests.controller.ts
+++ b/src/controllers/service-requests/service-requests.controller.ts
@@ -27,15 +27,21 @@ import {
   NestedSupportNetworkEntity,
   SupportNetworkListResponseSRExample,
 } from '../../entities/support-network.entity';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import {
+  attachmentIdName,
   CONTENT_TYPE,
   idName,
   sinceParamName,
 } from '../../common/constants/parameter-constants';
 import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
 import {
+  AttachmentDetailsEntity,
+  AttachmentDetailsSRExample,
   AttachmentsListResponseSRExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
@@ -170,6 +176,59 @@ export class ServiceRequestsController {
     filter?: FilterQueryParams,
   ): Promise<NestedAttachmentsEntity> {
     return await this.serviceRequestService.getSingleSRAttachmentRecord(
+      id,
+      res,
+      filter,
+    );
+  }
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Get(`:${idName}/attachments/:${attachmentIdName}`)
+  @ApiOperation({
+    description:
+      'Download an Attachment related to a given Service Request Id by its Attachment Id.',
+  })
+  @ApiQuery({ name: sinceParamName, required: false })
+  @ApiQuery({ name: recordCountNeededParamName, required: false })
+  @ApiQuery({ name: pageSizeParamName, required: false })
+  @ApiQuery({ name: startRowNumParamName, required: false })
+  @ApiExtraModels(AttachmentDetailsEntity)
+  @ApiOkResponse({
+    headers: totalRecordCountHeadersSwagger,
+    content: {
+      [CONTENT_TYPE]: {
+        schema: {
+          $ref: getSchemaPath(AttachmentDetailsEntity),
+        },
+        examples: {
+          AttachmentDetailsResponse: {
+            value: AttachmentDetailsSRExample,
+          },
+        },
+      },
+    },
+  })
+  async getSingleSRAttachmentDetailsRecord(
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: AttachmentIdPathParams,
+    @Res({ passthrough: true }) res: Response,
+    @Query(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+        skipMissingProperties: true,
+      }),
+    )
+    filter?: FilterQueryParams,
+  ): Promise<AttachmentDetailsEntity> {
+    return await this.serviceRequestService.getSingleSRAttachmentDetailsRecord(
       id,
       res,
       filter,

--- a/src/controllers/service-requests/service-requests.service.spec.ts
+++ b/src/controllers/service-requests/service-requests.service.spec.ts
@@ -10,17 +10,23 @@ import {
   SupportNetworkListResponseSRExample,
 } from '../../entities/support-network.entity';
 import { RecordType } from '../../common/constants/enumerations';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import {
+  attachmentIdName,
   idName,
   sinceParamName,
   srAttachmentsFieldName,
 } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import {
+  AttachmentDetailsEntity,
+  AttachmentDetailsSRExample,
   AttachmentsListResponseSRExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
@@ -146,6 +152,43 @@ describe('ServiceRequestsService', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleSRAttachmentDetailsRecord tests', () => {
+    it.each([
+      [
+        AttachmentDetailsSRExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        { [sinceParamName]: '2024-12-01' } as FilterQueryParams,
+        srAttachmentsFieldName,
+      ],
+    ])(
+      'should return nested values given good input',
+      async (data, idPathParams, filterQueryParams, typeFieldName) => {
+        const attachmentsSpy = jest
+          .spyOn(attachmentsService, 'getSingleAttachmentDetailsRecord')
+          .mockReturnValueOnce(
+            Promise.resolve(new AttachmentDetailsEntity(data)),
+          );
+
+        const result = await service.getSingleSRAttachmentDetailsRecord(
+          idPathParams,
+          res,
+          filterQueryParams,
+        );
+        expect(attachmentsSpy).toHaveBeenCalledWith(
+          RecordType.SR,
+          idPathParams,
+          typeFieldName,
+          res,
+          filterQueryParams,
+        );
+        expect(result).toEqual(new AttachmentDetailsEntity(data));
       },
     );
   });

--- a/src/controllers/service-requests/service-requests.service.ts
+++ b/src/controllers/service-requests/service-requests.service.ts
@@ -2,11 +2,17 @@ import { Injectable } from '@nestjs/common';
 import { SupportNetworkService } from '../../helpers/support-network/support-network.service';
 import { RecordType } from '../../common/constants/enumerations';
 import { NestedSupportNetworkEntity } from '../../entities/support-network.entity';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import { srAttachmentsFieldName } from '../../common/constants/parameter-constants';
-import { NestedAttachmentsEntity } from '../../entities/attachments.entity';
+import {
+  AttachmentDetailsEntity,
+  NestedAttachmentsEntity,
+} from '../../entities/attachments.entity';
 import { Response } from 'express';
 import { NestedContactsEntity } from '../../entities/contacts.entity';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
@@ -38,6 +44,20 @@ export class ServiceRequestsService {
     filter?: FilterQueryParams,
   ): Promise<NestedAttachmentsEntity> {
     return await this.attachmentsService.getSingleAttachmentRecord(
+      RecordType.SR,
+      id,
+      srAttachmentsFieldName,
+      res,
+      filter,
+    );
+  }
+
+  async getSingleSRAttachmentDetailsRecord(
+    id: AttachmentIdPathParams,
+    res: Response,
+    filter?: FilterQueryParams,
+  ): Promise<AttachmentDetailsEntity> {
+    return await this.attachmentsService.getSingleAttachmentDetailsRecord(
       RecordType.SR,
       id,
       srAttachmentsFieldName,

--- a/src/dto/id-path-params.dto.ts
+++ b/src/dto/id-path-params.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Matches } from 'class-validator';
 import {
+  attachmentIdName,
   idMaxLength,
   idName,
   idRegex,
@@ -15,4 +16,15 @@ export class IdPathParams {
     pattern: idRegex.toString().replaceAll('/', ''),
   })
   [idName]: string;
+}
+
+export class AttachmentIdPathParams extends IdPathParams {
+  @Matches(idRegex)
+  @ApiProperty({
+    example: 'Attachment-Id-Here',
+    description: 'The Id of the attachment you wish to download.',
+    maxLength: idMaxLength,
+    pattern: idRegex.toString().replaceAll('/', ''),
+  })
+  [attachmentIdName]: string;
 }

--- a/src/entities/api-not-found-error.entity.ts
+++ b/src/entities/api-not-found-error.entity.ts
@@ -1,0 +1,10 @@
+import { ApiSchema, ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+
+@Exclude()
+@ApiSchema({ name: 'NotFoundError' })
+export class ApiNotFoundErrorEntity {
+  @Expose()
+  @ApiProperty({ example: 'no Route matched with those values' })
+  message: string;
+}

--- a/src/entities/attachments.entity.ts
+++ b/src/entities/attachments.entity.ts
@@ -41,8 +41,12 @@ const AttachmentsSingleResponseCaseExample = {
   'Memo Id': '',
   MemoNumber: '',
   'SR Id': '',
-  'Attachment Id': 'Siebel Link Here',
   Id: 'Attachment-Id-Here',
+};
+
+export const AttachmentDetailsCaseExample = {
+  ...AttachmentsSingleResponseCaseExample,
+  'Attachment Id': 'base64 inline attachment here',
 };
 
 const AttachmentsSingleResponseIncidentExample = {
@@ -53,6 +57,11 @@ const AttachmentsSingleResponseIncidentExample = {
   'Incident No': 'Numeric-Incident-Id-Here',
 };
 
+export const AttachmentDetailsIncidentExample = {
+  ...AttachmentsSingleResponseIncidentExample,
+  'Attachment Id': 'base64 inline attachment here',
+};
+
 const AttachmentsSingleResponseSRExample = {
   ...AttachmentsSingleResponseCaseExample,
   'No Intervention': '',
@@ -61,12 +70,22 @@ const AttachmentsSingleResponseSRExample = {
   'SR Id': 'SR-Id-Here',
 };
 
+export const AttachmentDetailsSRExample = {
+  ...AttachmentsSingleResponseSRExample,
+  'Attachment Id': 'base64 inline attachment here',
+};
+
 const AttachmentsSingleResponseMemoExample = {
   ...AttachmentsSingleResponseCaseExample,
   'No Intervention': '',
   'Case Id': '',
   MemoNumber: 'Numeric-Memo-Id-Here',
   'Memo Id': 'Memo-Id-Here',
+};
+
+export const AttachmentDetailsMemoExample = {
+  ...AttachmentsSingleResponseMemoExample,
+  'Attachment Id': 'base64 inline attachment here',
 };
 
 export const AttachmentsListResponseCaseExample = {
@@ -348,12 +367,6 @@ class AttachmentsEntity {
   'SR Id': string;
 
   @ApiProperty({
-    example: AttachmentsSingleResponseCaseExample['Attachment Id'],
-  })
-  @Expose()
-  'Attachment Id': string;
-
-  @ApiProperty({
     example: AttachmentsSingleResponseCaseExample['Id'],
   })
   @Expose()
@@ -362,6 +375,16 @@ class AttachmentsEntity {
   constructor(partial: Partial<AttachmentsEntity>) {
     Object.assign(this, partial);
   }
+}
+
+@Exclude()
+@ApiSchema({ name: 'AttachmentDetailsResponse' })
+export class AttachmentDetailsEntity extends AttachmentsEntity {
+  @ApiProperty({
+    example: AttachmentDetailsCaseExample['Attachment Id'],
+  })
+  @Expose()
+  'Attachment Id': string;
 }
 
 @Exclude()

--- a/src/external-api/request-preparer/request-preparer.service.ts
+++ b/src/external-api/request-preparer/request-preparer.service.ts
@@ -96,6 +96,9 @@ export class RequestPreparerService {
         throw new Error('Upstream auth failed');
       }
       headers['Authorization'] = token;
+      console.log(url);
+      console.log(params);
+      console.log(headers);
       response = await firstValueFrom(
         this.httpService.get(url, { params, headers }),
       );
@@ -132,6 +135,7 @@ export class RequestPreparerService {
         response.headers[recordCountHeaderName],
       );
     }
+    console.log(response.data);
     return response;
   }
 

--- a/src/external-api/request-preparer/request-preparer.service.ts
+++ b/src/external-api/request-preparer/request-preparer.service.ts
@@ -96,9 +96,6 @@ export class RequestPreparerService {
         throw new Error('Upstream auth failed');
       }
       headers['Authorization'] = token;
-      console.log(url);
-      console.log(params);
-      console.log(headers);
       response = await firstValueFrom(
         this.httpService.get(url, { params, headers }),
       );
@@ -135,7 +132,6 @@ export class RequestPreparerService {
         response.headers[recordCountHeaderName],
       );
     }
-    console.log(response.data);
     return response;
   }
 

--- a/src/helpers/attachments/attachments.service.spec.ts
+++ b/src/helpers/attachments/attachments.service.spec.ts
@@ -8,12 +8,15 @@ import { TokenRefresherService } from '../../external-api/token-refresher/token-
 import { UtilitiesService } from '../utilities/utilities.service';
 import { RecordType } from '../../common/constants/enumerations';
 import {
+  attachmentIdName,
   idName,
   incidentsAttachmentsFieldName,
   sinceParamName,
 } from '../../common/constants/parameter-constants';
 import { AxiosResponse } from 'axios';
 import {
+  AttachmentDetailsEntity,
+  AttachmentDetailsIncidentExample,
   AttachmentsListResponseIncidentExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
@@ -85,6 +88,39 @@ describe('AttachmentsService', () => {
         );
         expect(spy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new NestedAttachmentsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleAttachmentDetailsRecord tests', () => {
+    it.each([
+      [
+        RecordType.Incident,
+        { [idName]: 'id', [attachmentIdName]: 'attachmentId' },
+        incidentsAttachmentsFieldName,
+        { [sinceParamName]: '2023-11-13' },
+        AttachmentDetailsIncidentExample,
+      ],
+    ])(
+      'should return a nested attachment entity given good inputs',
+      async (type, id, typeFieldName, filter, data) => {
+        const spy = jest
+          .spyOn(requestPreparerService, 'sendGetRequest')
+          .mockResolvedValueOnce({
+            data: data,
+            headers: {},
+            status: 200,
+            statusText: 'OK',
+          } as AxiosResponse<any, any>);
+        const result = await service.getSingleAttachmentDetailsRecord(
+          type,
+          id,
+          typeFieldName,
+          res,
+          filter,
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(new AttachmentDetailsEntity(data));
       },
     );
   });

--- a/src/helpers/attachments/attachments.service.ts
+++ b/src/helpers/attachments/attachments.service.ts
@@ -1,11 +1,23 @@
 import { Injectable } from '@nestjs/common';
 import { RecordType } from '../../common/constants/enumerations';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  AttachmentIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { ConfigService } from '@nestjs/config';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
-import { NestedAttachmentsEntity } from '../../entities/attachments.entity';
-import { idName } from '../../common/constants/parameter-constants';
+import {
+  AttachmentDetailsEntity,
+  NestedAttachmentsEntity,
+} from '../../entities/attachments.entity';
+import {
+  attachmentIdName,
+  idName,
+  INLINE_ATTACHMENT,
+  inlineAttachmentParamName,
+  uniformResponseParamName,
+} from '../../common/constants/parameter-constants';
 import { Response } from 'express';
 
 @Injectable()
@@ -47,5 +59,31 @@ export class AttachmentsService {
       params,
     );
     return new NestedAttachmentsEntity(response.data);
+  }
+
+  async getSingleAttachmentDetailsRecord(
+    _type: RecordType,
+    id: AttachmentIdPathParams,
+    typeFieldName: string,
+    res: Response,
+    filter?: FilterQueryParams,
+  ): Promise<AttachmentDetailsEntity> {
+    const baseSearchSpec = `([${typeFieldName}]="${id[idName]}"`;
+    const [headers, params] =
+      this.requestPreparerService.prepareHeadersAndParams(
+        baseSearchSpec,
+        this.workspace,
+        this.sinceFieldName,
+        filter,
+      );
+    params[inlineAttachmentParamName] = INLINE_ATTACHMENT;
+    params[uniformResponseParamName] = undefined;
+    const response = await this.requestPreparerService.sendGetRequest(
+      this.url + `/${id[attachmentIdName]}`,
+      headers,
+      res,
+      params,
+    );
+    return new AttachmentDetailsEntity(response.data);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,12 +4,15 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import { Logger } from 'nestjs-pino';
 import { Logger as NestJSLogger } from '@nestjs/common';
+import { versionRegexString } from './common/constants/parameter-constants';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     bufferLogs: true,
   });
   app.useLogger(app.get(Logger));
+
+  app.setGlobalPrefix(versionRegexString);
 
   const config = new DocumentBuilder()
     .setTitle('Visitz API')
@@ -18,8 +21,8 @@ async function bootstrap() {
     .addTag('visitz')
     .build();
   const documentFactory = () => SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api-spec', app, documentFactory, {
-    jsonDocumentUrl: 'api-spec/json',
+  SwaggerModule.setup(`${versionRegexString}/api-spec`, app, documentFactory, {
+    jsonDocumentUrl: `${versionRegexString}/api-spec/json`,
   });
 
   const port = process.env.PORT ?? 3000;


### PR DESCRIPTION
[Story link](https://bcsocialsector.service-now.com/now/nav/ui/classic/params/target/rm_story.do%3Fsys_id%3De1bc590293551a10e09fb1584dba10e0%26sysparm_view%3Dscrum%26sysparm_record_target%3Drm_story%26sysparm_record_row%3D22%26sysparm_record_rows%3D34%26sysparm_record_list%3Depic%253Db96a9b1d931dd210e09fb1584dba1091%255EORDERBYnumber)

This PR adds the GET /{case|incident|sr|memo}/{rowId}/attachments/{attachmentId} endpoints and associated unit tests / OpenAPI documentation.