### PR TITLE
Add single fetch endpoints

### DIFF
--- a/src/common/constants/parameter-constants.ts
+++ b/src/common/constants/parameter-constants.ts
@@ -13,6 +13,9 @@ const versionRegexString = 'v:version(\\d+)';
 const idRegex = /^[0-9\-A-Za-z]{1,100}$/;
 const idName = 'rowId';
 const attachmentIdName = 'attachmentId';
+const contactIdName = 'contactId';
+const supportNetworkIdName = 'supportNetworkId';
+const visitIdName = 'visitId';
 
 const casesAttachmentsFieldName = 'Case Id';
 const incidentsAttachmentsFieldName = 'Incident Id';
@@ -34,6 +37,9 @@ export {
   idRegex,
   idName,
   attachmentIdName,
+  contactIdName,
+  supportNetworkIdName,
+  visitIdName,
   casesAttachmentsFieldName,
   incidentsAttachmentsFieldName,
   srAttachmentsFieldName,

--- a/src/common/constants/parameter-constants.ts
+++ b/src/common/constants/parameter-constants.ts
@@ -21,6 +21,7 @@ const casesAttachmentsFieldName = 'Case Id';
 const incidentsAttachmentsFieldName = 'Incident Id';
 const srAttachmentsFieldName = 'SR Id';
 const memoAttachmentsFieldName = 'Memo Id';
+const attachmentIdFieldName = 'Attachment Id';
 
 export {
   VIEW_MODE,
@@ -44,4 +45,5 @@ export {
   incidentsAttachmentsFieldName,
   srAttachmentsFieldName,
   memoAttachmentsFieldName,
+  attachmentIdFieldName,
 };

--- a/src/controllers/cases/cases.controller.ts
+++ b/src/controllers/cases/cases.controller.ts
@@ -30,11 +30,14 @@ import {
 import { CasesService } from './cases.service';
 import {
   NestedSupportNetworkEntity,
+  SupportNetworkEntity,
   SupportNetworkListResponseCaseExample,
+  SupportNetworkSingleResponseCaseExample,
 } from '../../entities/support-network.entity';
 import {
   AttachmentIdPathParams,
   IdPathParams,
+  SupportNetworkIdPathParams,
 } from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import {
@@ -42,6 +45,7 @@ import {
   CONTENT_TYPE,
   idName,
   sinceParamName,
+  supportNetworkIdName,
 } from '../../common/constants/parameter-constants';
 import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
 import { AuthGuard } from '../../common/guards/auth/auth.guard';
@@ -90,26 +94,33 @@ export class CasesController {
   constructor(private readonly casesService: CasesService) {}
 
   @UseInterceptors(ClassSerializerInterceptor)
-  @Get(`:${idName}/support-network`)
+  @Get(`:${idName}/support-network/:${supportNetworkIdName}?`)
   @ApiOperation({
     description:
-      'Find all Support Network entries related to a given Case entity by Case id.',
+      `Find all Support Network entries related to a given Case entity by Case id. Optionally, if` +
+      ` ${supportNetworkIdName} is given, will display that single result if it is related to the given Case id.`,
   })
   @ApiQuery({ name: sinceParamName, required: false })
   @ApiQuery({ name: recordCountNeededParamName, required: false })
   @ApiQuery({ name: pageSizeParamName, required: false })
   @ApiQuery({ name: startRowNumParamName, required: false })
-  @ApiExtraModels(NestedSupportNetworkEntity)
   @ApiNoContentResponse(noContentResponseSwagger)
+  @ApiExtraModels(SupportNetworkEntity, NestedSupportNetworkEntity)
   @ApiOkResponse({
     headers: totalRecordCountHeadersSwagger,
     content: {
       [CONTENT_TYPE]: {
         schema: {
-          $ref: getSchemaPath(NestedSupportNetworkEntity),
+          oneOf: [
+            { $ref: getSchemaPath(SupportNetworkEntity) },
+            { $ref: getSchemaPath(NestedSupportNetworkEntity) },
+          ],
         },
         examples: {
-          SupportNetworkResponse: {
+          SupportNetworkSingleResponse: {
+            value: SupportNetworkSingleResponseCaseExample,
+          },
+          SupportNetworkListResponse: {
             value: SupportNetworkListResponseCaseExample,
           },
         },
@@ -124,7 +135,7 @@ export class CasesController {
         forbidNonWhitelisted: true,
       }),
     )
-    id: IdPathParams,
+    id: SupportNetworkIdPathParams,
     @Res({ passthrough: true }) res: Response,
     @Query(
       new ValidationPipe({
@@ -135,7 +146,7 @@ export class CasesController {
       }),
     )
     filter?: FilterQueryParams,
-  ): Promise<NestedSupportNetworkEntity> {
+  ): Promise<SupportNetworkEntity | NestedSupportNetworkEntity> {
     return await this.casesService.getSingleCaseSupportNetworkInformationRecord(
       id,
       res,

--- a/src/controllers/cases/cases.controller.ts
+++ b/src/controllers/cases/cases.controller.ts
@@ -282,8 +282,8 @@ export class CasesController {
     )
     id: VisitIdPathParams,
     @Res({ passthrough: true }) res: Response,
-  ): Promise<NestedInPersonVisitsEntity> {
-    return await this.casesService.getListCaseInPersonVisitRecord(id, res);
+  ): Promise<InPersonVisitsEntity> {
+    return await this.casesService.getSingleCaseInPersonVisitRecord(id, res);
   }
 
   @UseInterceptors(ClassSerializerInterceptor)

--- a/src/controllers/cases/cases.controller.ts
+++ b/src/controllers/cases/cases.controller.ts
@@ -41,12 +41,16 @@ import {
   SupportNetworkIdPathParams,
   VisitIdPathParams,
 } from '../../dto/id-path-params.dto';
-import { FilterQueryParams } from '../../dto/filter-query-params.dto';
+import {
+  AttachmentDetailsQueryParams,
+  FilterQueryParams,
+} from '../../dto/filter-query-params.dto';
 import {
   attachmentIdName,
   contactIdName,
   CONTENT_TYPE,
   idName,
+  inlineAttachmentParamName,
   sinceParamName,
   supportNetworkIdName,
   visitIdName,
@@ -64,6 +68,7 @@ import {
   AttachmentDetailsCaseExample,
   AttachmentDetailsEntity,
   AttachmentsListResponseCaseExample,
+  AttachmentsSingleResponseCaseExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import { PostInPersonVisitDto } from '../../dto/post-in-person-visit.dto';
@@ -388,6 +393,7 @@ export class CasesController {
   @ApiQuery({ name: recordCountNeededParamName, required: false })
   @ApiQuery({ name: pageSizeParamName, required: false })
   @ApiQuery({ name: startRowNumParamName, required: false })
+  @ApiQuery({ name: inlineAttachmentParamName, required: false })
   @ApiExtraModels(AttachmentDetailsEntity)
   @ApiNoContentResponse(noContentResponseSwagger)
   @ApiOkResponse({
@@ -398,8 +404,11 @@ export class CasesController {
           $ref: getSchemaPath(AttachmentDetailsEntity),
         },
         examples: {
-          AttachmentDetailsResponse: {
+          AttachmentDetailsDownloadResponse: {
             value: AttachmentDetailsCaseExample,
+          },
+          AttachmentDetailsNoDownloadResponse: {
+            value: AttachmentsSingleResponseCaseExample,
           },
         },
       },
@@ -423,7 +432,7 @@ export class CasesController {
         skipMissingProperties: true,
       }),
     )
-    filter?: FilterQueryParams,
+    filter?: AttachmentDetailsQueryParams,
   ): Promise<AttachmentDetailsEntity> {
     return await this.casesService.getSingleCaseAttachmentDetailsRecord(
       id,

--- a/src/controllers/cases/cases.service.spec.ts
+++ b/src/controllers/cases/cases.service.spec.ts
@@ -7,33 +7,48 @@ import { SupportNetworkService } from '../../helpers/support-network/support-net
 import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import {
   NestedSupportNetworkEntity,
+  SupportNetworkEntity,
   SupportNetworkListResponseCaseExample,
+  SupportNetworkSingleResponseCaseExample,
 } from '../../entities/support-network.entity';
 import {
   AttachmentIdPathParams,
+  ContactIdPathParams,
   IdPathParams,
+  SupportNetworkIdPathParams,
+  VisitIdPathParams,
 } from '../../dto/id-path-params.dto';
-import { FilterQueryParams } from '../../dto/filter-query-params.dto';
+import {
+  AttachmentDetailsQueryParams,
+  FilterQueryParams,
+} from '../../dto/filter-query-params.dto';
 import { RecordType, VisitDetails } from '../../common/constants/enumerations';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { InPersonVisitsService } from '../../helpers/in-person-visits/in-person-visits.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import {
+  InPersonVisitsEntity,
   InPersonVisitsListResponseCaseExample,
+  InPersonVisitsSingleResponseCaseExample,
   NestedInPersonVisitsEntity,
   PostInPersonVisitResponseExample,
 } from '../../entities/in-person-visits.entity';
 import {
   attachmentIdName,
   casesAttachmentsFieldName,
+  contactIdName,
   idName,
+  inlineAttachmentParamName,
   sinceParamName,
+  supportNetworkIdName,
+  visitIdName,
 } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import {
   AttachmentDetailsCaseExample,
   AttachmentDetailsEntity,
   AttachmentsListResponseCaseExample,
+  AttachmentsSingleResponseCaseExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import { getMockRes } from '@jest-mock/express';
@@ -41,7 +56,9 @@ import { startRowNumParamName } from '../../common/constants/upstream-constants'
 import configuration from '../../configuration/configuration';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
 import {
+  ContactsEntity,
   ContactsListResponseCaseExample,
+  ContactsSingleResponseCaseExample,
   NestedContactsEntity,
 } from '../../entities/contacts.entity';
 
@@ -91,7 +108,7 @@ describe('CasesService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('getSingleCaseSupportNetworkInformationRecord tests', () => {
+  describe('getListCaseSupportNetworkInformationRecord tests', () => {
     it.each([
       [
         SupportNetworkListResponseCaseExample,
@@ -104,18 +121,17 @@ describe('CasesService', () => {
         const supportNetworkSpy = jest
           .spyOn(
             supportNetworkService,
-            'getSingleSupportNetworkInformationRecord',
+            'getListSupportNetworkInformationRecord',
           )
           .mockReturnValueOnce(
             Promise.resolve(new NestedSupportNetworkEntity(data)),
           );
 
-        const result =
-          await service.getSingleCaseSupportNetworkInformationRecord(
-            idPathParams,
-            res,
-            filterQueryParams,
-          );
+        const result = await service.getListCaseSupportNetworkInformationRecord(
+          idPathParams,
+          res,
+          filterQueryParams,
+        );
         expect(supportNetworkSpy).toHaveBeenCalledWith(
           RecordType.Case,
           idPathParams,
@@ -127,7 +143,41 @@ describe('CasesService', () => {
     );
   });
 
-  describe('getSingleCaseInPersonVisitRecord tests', () => {
+  describe('getSingleCaseSupportNetworkInformationRecord tests', () => {
+    it.each([
+      [
+        SupportNetworkSingleResponseCaseExample,
+        {
+          [idName]: 'test',
+          [supportNetworkIdName]: 'test2',
+        } as SupportNetworkIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams) => {
+        const supportNetworkSpy = jest
+          .spyOn(
+            supportNetworkService,
+            'getSingleSupportNetworkInformationRecord',
+          )
+          .mockReturnValueOnce(Promise.resolve(new SupportNetworkEntity(data)));
+
+        const result =
+          await service.getSingleCaseSupportNetworkInformationRecord(
+            idPathParams,
+            res,
+          );
+        expect(supportNetworkSpy).toHaveBeenCalledWith(
+          RecordType.Case,
+          idPathParams,
+          res,
+        );
+        expect(result).toEqual(new SupportNetworkEntity(data));
+      },
+    );
+  });
+
+  describe('getListCaseInPersonVisitRecord tests', () => {
     it.each([
       [
         InPersonVisitsListResponseCaseExample,
@@ -141,12 +191,12 @@ describe('CasesService', () => {
       'should return nested values given good input',
       async (data, idPathParams, filterQueryParams) => {
         const InPersonVisitsSpy = jest
-          .spyOn(inPersonVisitsService, 'getSingleInPersonVisitRecord')
+          .spyOn(inPersonVisitsService, 'getListInPersonVisitRecord')
           .mockReturnValueOnce(
             Promise.resolve(new NestedInPersonVisitsEntity(data)),
           );
 
-        const result = await service.getSingleCaseInPersonVisitRecord(
+        const result = await service.getListCaseInPersonVisitRecord(
           idPathParams,
           res,
           filterQueryParams,
@@ -158,6 +208,33 @@ describe('CasesService', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedInPersonVisitsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleCaseInPersonVisitRecord tests', () => {
+    it.each([
+      [
+        InPersonVisitsSingleResponseCaseExample,
+        { [idName]: 'test', [visitIdName]: 'test2' } as VisitIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams) => {
+        const InPersonVisitsSpy = jest
+          .spyOn(inPersonVisitsService, 'getSingleInPersonVisitRecord')
+          .mockReturnValueOnce(Promise.resolve(new InPersonVisitsEntity(data)));
+
+        const result = await service.getSingleCaseInPersonVisitRecord(
+          idPathParams,
+          res,
+        );
+        expect(InPersonVisitsSpy).toHaveBeenCalledWith(
+          RecordType.Case,
+          idPathParams,
+          res,
+        );
+        expect(result).toEqual(new InPersonVisitsEntity(data));
       },
     );
   });
@@ -236,11 +313,23 @@ describe('CasesService', () => {
           [idName]: 'test',
           [attachmentIdName]: 'attachmenttest',
         } as AttachmentIdPathParams,
-        { [sinceParamName]: '2024-12-01' } as FilterQueryParams,
+        { [sinceParamName]: '2024-12-01' } as AttachmentDetailsQueryParams,
+        casesAttachmentsFieldName,
+      ],
+      [
+        AttachmentsSingleResponseCaseExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        {
+          [sinceParamName]: '2024-12-01',
+          [inlineAttachmentParamName]: 'false',
+        } as AttachmentDetailsQueryParams,
         casesAttachmentsFieldName,
       ],
     ])(
-      'should return nested values given good input',
+      'should return single values given good input',
       async (data, idPathParams, filterQueryParams, typeFieldName) => {
         const attachmentsSpy = jest
           .spyOn(attachmentsService, 'getSingleAttachmentDetailsRecord')
@@ -265,7 +354,7 @@ describe('CasesService', () => {
     );
   });
 
-  describe('getSingleCaseContactRecord tests', () => {
+  describe('getListCaseContactRecord tests', () => {
     it.each([
       [
         ContactsListResponseCaseExample,
@@ -279,10 +368,10 @@ describe('CasesService', () => {
       'should return nested values given good input',
       async (data, idPathParams, filterQueryParams) => {
         const contactsSpy = jest
-          .spyOn(contactsService, 'getSingleContactRecord')
+          .spyOn(contactsService, 'getListContactRecord')
           .mockReturnValueOnce(Promise.resolve(new NestedContactsEntity(data)));
 
-        const result = await service.getSingleCaseContactRecord(
+        const result = await service.getListCaseContactRecord(
           idPathParams,
           res,
           filterQueryParams,
@@ -294,6 +383,33 @@ describe('CasesService', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleCaseContactRecord tests', () => {
+    it.each([
+      [
+        ContactsSingleResponseCaseExample,
+        { [idName]: 'test', [contactIdName]: 'test2' } as ContactIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams) => {
+        const contactsSpy = jest
+          .spyOn(contactsService, 'getSingleContactRecord')
+          .mockReturnValueOnce(Promise.resolve(new ContactsEntity(data)));
+
+        const result = await service.getSingleCaseContactRecord(
+          idPathParams,
+          res,
+        );
+        expect(contactsSpy).toHaveBeenCalledWith(
+          RecordType.Case,
+          idPathParams,
+          res,
+        );
+        expect(result).toEqual(new ContactsEntity(data));
       },
     );
   });

--- a/src/controllers/cases/cases.service.ts
+++ b/src/controllers/cases/cases.service.ts
@@ -12,7 +12,10 @@ import {
   SupportNetworkIdPathParams,
   VisitIdPathParams,
 } from '../../dto/id-path-params.dto';
-import { FilterQueryParams } from '../../dto/filter-query-params.dto';
+import {
+  AttachmentDetailsQueryParams,
+  FilterQueryParams,
+} from '../../dto/filter-query-params.dto';
 import { InPersonVisitsService } from '../../helpers/in-person-visits/in-person-visits.service';
 import {
   InPersonVisitsEntity,
@@ -132,7 +135,7 @@ export class CasesService {
   async getSingleCaseAttachmentDetailsRecord(
     id: AttachmentIdPathParams,
     res: Response,
-    filter?: FilterQueryParams,
+    filter?: AttachmentDetailsQueryParams,
   ): Promise<AttachmentDetailsEntity> {
     return await this.attachmentsService.getSingleAttachmentDetailsRecord(
       RecordType.Case,

--- a/src/controllers/cases/cases.service.ts
+++ b/src/controllers/cases/cases.service.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { SupportNetworkService } from '../../helpers/support-network/support-network.service';
 import { RecordType } from '../../common/constants/enumerations';
-import { NestedSupportNetworkEntity } from '../../entities/support-network.entity';
+import {
+  NestedSupportNetworkEntity,
+  SupportNetworkEntity,
+} from '../../entities/support-network.entity';
 import {
   AttachmentIdPathParams,
   IdPathParams,
+  SupportNetworkIdPathParams,
 } from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { InPersonVisitsService } from '../../helpers/in-person-visits/in-person-visits.service';
@@ -40,10 +44,10 @@ export class CasesService {
   ) {}
 
   async getSingleCaseSupportNetworkInformationRecord(
-    id: IdPathParams,
+    id: SupportNetworkIdPathParams,
     res: Response,
     filter?: FilterQueryParams,
-  ): Promise<NestedSupportNetworkEntity> {
+  ): Promise<SupportNetworkEntity | NestedSupportNetworkEntity> {
     return await this.supportNetworkService.getSingleSupportNetworkInformationRecord(
       RecordType.Case,
       id,

--- a/src/controllers/cases/cases.service.ts
+++ b/src/controllers/cases/cases.service.ts
@@ -7,12 +7,17 @@ import {
 } from '../../entities/support-network.entity';
 import {
   AttachmentIdPathParams,
+  ContactIdPathParams,
   IdPathParams,
   SupportNetworkIdPathParams,
+  VisitIdPathParams,
 } from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { InPersonVisitsService } from '../../helpers/in-person-visits/in-person-visits.service';
-import { NestedInPersonVisitsEntity } from '../../entities/in-person-visits.entity';
+import {
+  InPersonVisitsEntity,
+  NestedInPersonVisitsEntity,
+} from '../../entities/in-person-visits.entity';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import {
   AttachmentDetailsEntity,
@@ -32,7 +37,10 @@ import {
 } from '../../common/constants/upstream-constants';
 import { Response } from 'express';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
-import { NestedContactsEntity } from '../../entities/contacts.entity';
+import {
+  ContactsEntity,
+  NestedContactsEntity,
+} from '../../entities/contacts.entity';
 
 @Injectable()
 export class CasesService {
@@ -46,9 +54,20 @@ export class CasesService {
   async getSingleCaseSupportNetworkInformationRecord(
     id: SupportNetworkIdPathParams,
     res: Response,
-    filter?: FilterQueryParams,
-  ): Promise<SupportNetworkEntity | NestedSupportNetworkEntity> {
+  ): Promise<SupportNetworkEntity> {
     return await this.supportNetworkService.getSingleSupportNetworkInformationRecord(
+      RecordType.Case,
+      id,
+      res,
+    );
+  }
+
+  async getListCaseSupportNetworkInformationRecord(
+    id: IdPathParams,
+    res: Response,
+    filter?: FilterQueryParams,
+  ): Promise<NestedSupportNetworkEntity> {
+    return await this.supportNetworkService.getListSupportNetworkInformationRecord(
       RecordType.Case,
       id,
       res,
@@ -57,11 +76,22 @@ export class CasesService {
   }
 
   async getSingleCaseInPersonVisitRecord(
+    id: VisitIdPathParams,
+    res: Response,
+  ): Promise<InPersonVisitsEntity> {
+    return await this.inPersonVisitsService.getSingleInPersonVisitRecord(
+      RecordType.Case,
+      id,
+      res,
+    );
+  }
+
+  async getListCaseInPersonVisitRecord(
     id: IdPathParams,
     res: Response,
     filter?: FilterQueryParams,
   ): Promise<NestedInPersonVisitsEntity> {
-    return await this.inPersonVisitsService.getSingleInPersonVisitRecord(
+    return await this.inPersonVisitsService.getListInPersonVisitRecord(
       RecordType.Case,
       id,
       res,
@@ -114,11 +144,22 @@ export class CasesService {
   }
 
   async getSingleCaseContactRecord(
+    id: ContactIdPathParams,
+    res: Response,
+  ): Promise<ContactsEntity> {
+    return await this.contactsService.getSingleContactRecord(
+      RecordType.Case,
+      id,
+      res,
+    );
+  }
+
+  async getListCaseContactRecord(
     id: IdPathParams,
     res: Response,
     filter?: FilterQueryParams,
   ): Promise<NestedContactsEntity> {
-    return await this.contactsService.getSingleContactRecord(
+    return await this.contactsService.getListContactRecord(
       RecordType.Case,
       id,
       res,

--- a/src/controllers/incidents/incidents.controller.spec.ts
+++ b/src/controllers/incidents/incidents.controller.spec.ts
@@ -6,12 +6,19 @@ import { IncidentsController } from './incidents.controller';
 import { IncidentsService } from './incidents.service';
 import {
   NestedSupportNetworkEntity,
+  SupportNetworkEntity,
   SupportNetworkListResponseIncidentExample,
+  SupportNetworkSingleResponseIncidentExample,
 } from '../../entities/support-network.entity';
-import { FilterQueryParams } from '../../dto/filter-query-params.dto';
+import {
+  AttachmentDetailsQueryParams,
+  FilterQueryParams,
+} from '../../dto/filter-query-params.dto';
 import {
   AttachmentIdPathParams,
+  ContactIdPathParams,
   IdPathParams,
+  SupportNetworkIdPathParams,
 } from '../../dto/id-path-params.dto';
 import { AuthService } from '../../common/guards/auth/auth.service';
 import { SupportNetworkService } from '../../helpers/support-network/support-network.service';
@@ -20,14 +27,18 @@ import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import {
   attachmentIdName,
+  contactIdName,
   idName,
+  inlineAttachmentParamName,
   sinceParamName,
+  supportNetworkIdName,
 } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import {
   AttachmentDetailsEntity,
   AttachmentDetailsIncidentExample,
   AttachmentsListResponseIncidentExample,
+  AttachmentsSingleResponseIncidentExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import { getMockRes } from '@jest-mock/express';
@@ -35,7 +46,9 @@ import { startRowNumParamName } from '../../common/constants/upstream-constants'
 import configuration from '../../configuration/configuration';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
 import {
+  ContactsEntity,
   ContactsListResponseIncidentExample,
+  ContactsSingleResponseIncidentExample,
   NestedContactsEntity,
 } from '../../entities/contacts.entity';
 
@@ -72,7 +85,7 @@ describe('IncidentsController', () => {
     expect(controller).toBeDefined();
   });
 
-  describe('getSingleIncidentSupportNetworkInformationRecord tests', () => {
+  describe('getListIncidentSupportNetworkInformationRecord tests', () => {
     it.each([
       [
         SupportNetworkListResponseIncidentExample,
@@ -88,14 +101,14 @@ describe('IncidentsController', () => {
         const IncidentsServiceSpy = jest
           .spyOn(
             incidentsService,
-            'getSingleIncidentSupportNetworkInformationRecord',
+            'getListIncidentSupportNetworkInformationRecord',
           )
           .mockReturnValueOnce(
             Promise.resolve(new NestedSupportNetworkEntity(data)),
           );
 
         const result =
-          await controller.getSingleIncidentSupportNetworkInformationRecord(
+          await controller.getListIncidentSupportNetworkInformationRecord(
             idPathParams,
             res,
             filterQueryParams,
@@ -106,6 +119,36 @@ describe('IncidentsController', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedSupportNetworkEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleIncidentSupportNetworkInformationRecord tests', () => {
+    it.each([
+      [
+        SupportNetworkSingleResponseIncidentExample,
+        {
+          [idName]: 'test',
+          [supportNetworkIdName]: 'test2',
+        } as SupportNetworkIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams) => {
+        const IncidentsServiceSpy = jest
+          .spyOn(
+            incidentsService,
+            'getSingleIncidentSupportNetworkInformationRecord',
+          )
+          .mockReturnValueOnce(Promise.resolve(new SupportNetworkEntity(data)));
+
+        const result =
+          await controller.getSingleIncidentSupportNetworkInformationRecord(
+            idPathParams,
+            res,
+          );
+        expect(IncidentsServiceSpy).toHaveBeenCalledWith(idPathParams, res);
+        expect(result).toEqual(new SupportNetworkEntity(data));
       },
     );
   });
@@ -155,10 +198,22 @@ describe('IncidentsController', () => {
         {
           [sinceParamName]: '2020-02-02',
           [startRowNumParamName]: 0,
-        } as FilterQueryParams,
+        } as AttachmentDetailsQueryParams,
+      ],
+      [
+        AttachmentsSingleResponseIncidentExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        {
+          [sinceParamName]: '2020-02-02',
+          [startRowNumParamName]: 0,
+          [inlineAttachmentParamName]: 'false',
+        } as AttachmentDetailsQueryParams,
       ],
     ])(
-      'should return nested values given good input',
+      'should return single values given good input',
       async (data, idPathParams, filterQueryParams) => {
         const incidentServiceSpy = jest
           .spyOn(incidentsService, 'getSingleIncidentAttachmentDetailsRecord')
@@ -182,7 +237,7 @@ describe('IncidentsController', () => {
     );
   });
 
-  describe('getSingleIncidentContactRecord tests', () => {
+  describe('getListIncidentContactRecord tests', () => {
     it.each([
       [
         ContactsListResponseIncidentExample,
@@ -196,10 +251,10 @@ describe('IncidentsController', () => {
       'should return nested values given good input',
       async (data, idPathParams, filterQueryParams) => {
         const incidentServiceSpy = jest
-          .spyOn(incidentsService, 'getSingleIncidentContactRecord')
+          .spyOn(incidentsService, 'getListIncidentContactRecord')
           .mockReturnValueOnce(Promise.resolve(new NestedContactsEntity(data)));
 
-        const result = await controller.getSingleIncidentContactRecord(
+        const result = await controller.getListIncidentContactRecord(
           idPathParams,
           res,
           filterQueryParams,
@@ -210,6 +265,29 @@ describe('IncidentsController', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleIncidentContactRecord tests', () => {
+    it.each([
+      [
+        ContactsSingleResponseIncidentExample,
+        { [idName]: 'test', [contactIdName]: 'test2' } as ContactIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams) => {
+        const incidentServiceSpy = jest
+          .spyOn(incidentsService, 'getSingleIncidentContactRecord')
+          .mockReturnValueOnce(Promise.resolve(new ContactsEntity(data)));
+
+        const result = await controller.getSingleIncidentContactRecord(
+          idPathParams,
+          res,
+        );
+        expect(incidentServiceSpy).toHaveBeenCalledWith(idPathParams, res);
+        expect(result).toEqual(new ContactsEntity(data));
       },
     );
   });

--- a/src/controllers/incidents/incidents.controller.ts
+++ b/src/controllers/incidents/incidents.controller.ts
@@ -37,12 +37,16 @@ import {
   IdPathParams,
   SupportNetworkIdPathParams,
 } from '../../dto/id-path-params.dto';
-import { FilterQueryParams } from '../../dto/filter-query-params.dto';
+import {
+  AttachmentDetailsQueryParams,
+  FilterQueryParams,
+} from '../../dto/filter-query-params.dto';
 import {
   attachmentIdName,
   contactIdName,
   CONTENT_TYPE,
   idName,
+  inlineAttachmentParamName,
   sinceParamName,
   supportNetworkIdName,
 } from '../../common/constants/parameter-constants';
@@ -53,6 +57,7 @@ import {
   AttachmentsListResponseIncidentExample,
   AttachmentDetailsEntity,
   AttachmentDetailsIncidentExample,
+  AttachmentsSingleResponseIncidentExample,
 } from '../../entities/attachments.entity';
 import { Response } from 'express';
 import {
@@ -240,6 +245,7 @@ export class IncidentsController {
   @ApiQuery({ name: recordCountNeededParamName, required: false })
   @ApiQuery({ name: pageSizeParamName, required: false })
   @ApiQuery({ name: startRowNumParamName, required: false })
+  @ApiQuery({ name: inlineAttachmentParamName, required: false })
   @ApiExtraModels(AttachmentDetailsEntity)
   @ApiOkResponse({
     headers: totalRecordCountHeadersSwagger,
@@ -249,8 +255,11 @@ export class IncidentsController {
           $ref: getSchemaPath(AttachmentDetailsEntity),
         },
         examples: {
-          AttachmentDetailsResponse: {
+          AttachmentDetailsDownloadResponse: {
             value: AttachmentDetailsIncidentExample,
+          },
+          AttachmentDetailsNoDownloadResponse: {
+            value: AttachmentsSingleResponseIncidentExample,
           },
         },
       },
@@ -274,7 +283,7 @@ export class IncidentsController {
         skipMissingProperties: true,
       }),
     )
-    filter?: FilterQueryParams,
+    filter?: AttachmentDetailsQueryParams,
   ): Promise<AttachmentDetailsEntity> {
     return await this.incidentsService.getSingleIncidentAttachmentDetailsRecord(
       id,

--- a/src/controllers/incidents/incidents.controller.ts
+++ b/src/controllers/incidents/incidents.controller.ts
@@ -27,11 +27,14 @@ import {
 import { IncidentsService } from './incidents.service';
 import {
   NestedSupportNetworkEntity,
+  SupportNetworkEntity,
   SupportNetworkListResponseIncidentExample,
+  SupportNetworkSingleResponseIncidentExample,
 } from '../../entities/support-network.entity';
 import {
   AttachmentIdPathParams,
   IdPathParams,
+  SupportNetworkIdPathParams,
 } from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import {
@@ -39,6 +42,7 @@ import {
   CONTENT_TYPE,
   idName,
   sinceParamName,
+  supportNetworkIdName,
 } from '../../common/constants/parameter-constants';
 import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
 import { AuthGuard } from '../../common/guards/auth/auth.guard';
@@ -81,26 +85,32 @@ export class IncidentsController {
   constructor(private readonly incidentsService: IncidentsService) {}
 
   @UseInterceptors(ClassSerializerInterceptor)
-  @Get(`:${idName}/support-network`)
+  @Get(`:${idName}/support-network/:${supportNetworkIdName}?`)
   @ApiOperation({
     description:
-      'Find all Support Network entries related to a given Incident entity by Incident id.',
+      `Find all Support Network entries related to a given Incident entity by Incident id. Optionally, if` +
+      ` ${supportNetworkIdName} is given, will display that single result if it is related to the given Incident id.`,
   })
   @ApiQuery({ name: sinceParamName, required: false })
   @ApiQuery({ name: recordCountNeededParamName, required: false })
   @ApiQuery({ name: pageSizeParamName, required: false })
   @ApiQuery({ name: startRowNumParamName, required: false })
-  @ApiExtraModels(NestedSupportNetworkEntity)
+  @ApiExtraModels(SupportNetworkEntity, NestedSupportNetworkEntity)
   @ApiOkResponse({
     headers: totalRecordCountHeadersSwagger,
     content: {
       [CONTENT_TYPE]: {
         schema: {
-          $ref: getSchemaPath(NestedSupportNetworkEntity),
+          oneOf: [
+            { $ref: getSchemaPath(SupportNetworkEntity) },
+            { $ref: getSchemaPath(NestedSupportNetworkEntity) },
+          ],
         },
-
         examples: {
-          SupportNetworkResponse: {
+          SupportNetworkSingleResponse: {
+            value: SupportNetworkSingleResponseIncidentExample,
+          },
+          SupportNetworkListResponse: {
             value: SupportNetworkListResponseIncidentExample,
           },
         },
@@ -115,7 +125,7 @@ export class IncidentsController {
         forbidNonWhitelisted: true,
       }),
     )
-    id: IdPathParams,
+    id: SupportNetworkIdPathParams,
     @Res({ passthrough: true }) res: Response,
     @Query(
       new ValidationPipe({
@@ -126,7 +136,7 @@ export class IncidentsController {
       }),
     )
     filter?: FilterQueryParams,
-  ): Promise<NestedSupportNetworkEntity> {
+  ): Promise<SupportNetworkEntity | NestedSupportNetworkEntity> {
     return await this.incidentsService.getSingleIncidentSupportNetworkInformationRecord(
       id,
       res,

--- a/src/controllers/incidents/incidents.controller.ts
+++ b/src/controllers/incidents/incidents.controller.ts
@@ -33,12 +33,14 @@ import {
 } from '../../entities/support-network.entity';
 import {
   AttachmentIdPathParams,
+  ContactIdPathParams,
   IdPathParams,
   SupportNetworkIdPathParams,
 } from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import {
   attachmentIdName,
+  contactIdName,
   CONTENT_TYPE,
   idName,
   sinceParamName,
@@ -66,6 +68,8 @@ import {
 import {
   NestedContactsEntity,
   ContactsListResponseIncidentExample,
+  ContactsEntity,
+  ContactsSingleResponseIncidentExample,
 } from '../../entities/contacts.entity';
 import { ApiUnauthorizedErrorEntity } from '../../entities/api-unauthorized-error.entity';
 import { ApiForbiddenErrorEntity } from '../../entities/api-forbidden-error.entity';
@@ -85,33 +89,72 @@ export class IncidentsController {
   constructor(private readonly incidentsService: IncidentsService) {}
 
   @UseInterceptors(ClassSerializerInterceptor)
-  @Get(`:${idName}/support-network/:${supportNetworkIdName}?`)
+  @Get(`:${idName}/support-network`)
   @ApiOperation({
-    description:
-      `Find all Support Network entries related to a given Incident entity by Incident id. Optionally, if` +
-      ` ${supportNetworkIdName} is given, will display that single result if it is related to the given Incident id.`,
+    description: `Find all Support Network entries related to a given Incident entity by Incident id.`,
   })
   @ApiQuery({ name: sinceParamName, required: false })
   @ApiQuery({ name: recordCountNeededParamName, required: false })
   @ApiQuery({ name: pageSizeParamName, required: false })
   @ApiQuery({ name: startRowNumParamName, required: false })
-  @ApiExtraModels(SupportNetworkEntity, NestedSupportNetworkEntity)
+  @ApiExtraModels(NestedSupportNetworkEntity)
   @ApiOkResponse({
     headers: totalRecordCountHeadersSwagger,
     content: {
       [CONTENT_TYPE]: {
         schema: {
-          oneOf: [
-            { $ref: getSchemaPath(SupportNetworkEntity) },
-            { $ref: getSchemaPath(NestedSupportNetworkEntity) },
-          ],
+          $ref: getSchemaPath(NestedSupportNetworkEntity),
+        },
+        examples: {
+          SupportNetworkListResponse: {
+            value: SupportNetworkListResponseIncidentExample,
+          },
+        },
+      },
+    },
+  })
+  async getListIncidentSupportNetworkInformationRecord(
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: IdPathParams,
+    @Res({ passthrough: true }) res: Response,
+    @Query(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+        skipMissingProperties: true,
+      }),
+    )
+    filter?: FilterQueryParams,
+  ): Promise<NestedSupportNetworkEntity> {
+    return await this.incidentsService.getListIncidentSupportNetworkInformationRecord(
+      id,
+      res,
+      filter,
+    );
+  }
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Get(`:${idName}/support-network/:${supportNetworkIdName}`)
+  @ApiOperation({
+    description: `Displays the single ${supportNetworkIdName} result if it is related to the given Incident id.`,
+  })
+  @ApiExtraModels(SupportNetworkEntity)
+  @ApiOkResponse({
+    content: {
+      [CONTENT_TYPE]: {
+        schema: {
+          $ref: getSchemaPath(SupportNetworkEntity),
         },
         examples: {
           SupportNetworkSingleResponse: {
             value: SupportNetworkSingleResponseIncidentExample,
-          },
-          SupportNetworkListResponse: {
-            value: SupportNetworkListResponseIncidentExample,
           },
         },
       },
@@ -127,20 +170,10 @@ export class IncidentsController {
     )
     id: SupportNetworkIdPathParams,
     @Res({ passthrough: true }) res: Response,
-    @Query(
-      new ValidationPipe({
-        transform: true,
-        transformOptions: { enableImplicitConversion: true },
-        forbidNonWhitelisted: true,
-        skipMissingProperties: true,
-      }),
-    )
-    filter?: FilterQueryParams,
-  ): Promise<SupportNetworkEntity | NestedSupportNetworkEntity> {
+  ): Promise<SupportNetworkEntity> {
     return await this.incidentsService.getSingleIncidentSupportNetworkInformationRecord(
       id,
       res,
-      filter,
     );
   }
 
@@ -269,14 +302,14 @@ export class IncidentsController {
           $ref: getSchemaPath(NestedContactsEntity),
         },
         examples: {
-          ContactsResponse: {
+          ContactsListResponse: {
             value: ContactsListResponseIncidentExample,
           },
         },
       },
     },
   })
-  async getSingleIncidentContactRecord(
+  async getListIncidentContactRecord(
     @Param(
       new ValidationPipe({
         transform: true,
@@ -296,10 +329,44 @@ export class IncidentsController {
     )
     filter?: FilterQueryParams,
   ): Promise<NestedContactsEntity> {
-    return await this.incidentsService.getSingleIncidentContactRecord(
+    return await this.incidentsService.getListIncidentContactRecord(
       id,
       res,
       filter,
     );
+  }
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Get(`:${idName}/contacts/:${contactIdName}`)
+  @ApiOperation({
+    description: `Displays the single ${contactIdName} result if it is related to the given Incident id.`,
+  })
+  @ApiExtraModels(ContactsEntity)
+  @ApiOkResponse({
+    content: {
+      [CONTENT_TYPE]: {
+        schema: {
+          $ref: getSchemaPath(ContactsEntity),
+        },
+        examples: {
+          ContactsSingleResponse: {
+            value: ContactsSingleResponseIncidentExample,
+          },
+        },
+      },
+    },
+  })
+  async getSingleIncidentContactRecord(
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: ContactIdPathParams,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<ContactsEntity> {
+    return await this.incidentsService.getSingleIncidentContactRecord(id, res);
   }
 }

--- a/src/controllers/incidents/incidents.service.spec.ts
+++ b/src/controllers/incidents/incidents.service.spec.ts
@@ -7,27 +7,38 @@ import { SupportNetworkService } from '../../helpers/support-network/support-net
 import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import {
   NestedSupportNetworkEntity,
+  SupportNetworkEntity,
   SupportNetworkListResponseIncidentExample,
+  SupportNetworkSingleResponseIncidentExample,
 } from '../../entities/support-network.entity';
-import { FilterQueryParams } from '../../dto/filter-query-params.dto';
+import {
+  AttachmentDetailsQueryParams,
+  FilterQueryParams,
+} from '../../dto/filter-query-params.dto';
 import {
   AttachmentIdPathParams,
+  ContactIdPathParams,
   IdPathParams,
+  SupportNetworkIdPathParams,
 } from '../../dto/id-path-params.dto';
 import { RecordType } from '../../common/constants/enumerations';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import {
   attachmentIdName,
+  contactIdName,
   idName,
   incidentsAttachmentsFieldName,
+  inlineAttachmentParamName,
   sinceParamName,
+  supportNetworkIdName,
 } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import {
   AttachmentDetailsEntity,
   AttachmentDetailsIncidentExample,
   AttachmentsListResponseIncidentExample,
+  AttachmentsSingleResponseIncidentExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import { getMockRes } from '@jest-mock/express';
@@ -35,7 +46,9 @@ import { startRowNumParamName } from '../../common/constants/upstream-constants'
 import configuration from '../../configuration/configuration';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
 import {
+  ContactsEntity,
   ContactsListResponseIncidentExample,
+  ContactsSingleResponseIncidentExample,
   NestedContactsEntity,
 } from '../../entities/contacts.entity';
 
@@ -80,7 +93,7 @@ describe('IncidentsService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('getSingleIncidentSupportNetworkInformationRecord tests', () => {
+  describe('getListIncidentSupportNetworkInformationRecord tests', () => {
     it.each([
       [
         SupportNetworkListResponseIncidentExample,
@@ -96,14 +109,14 @@ describe('IncidentsService', () => {
         const supportNetworkSpy = jest
           .spyOn(
             supportNetworkService,
-            'getSingleSupportNetworkInformationRecord',
+            'getListSupportNetworkInformationRecord',
           )
           .mockReturnValueOnce(
             Promise.resolve(new NestedSupportNetworkEntity(data)),
           );
 
         const result =
-          await service.getSingleIncidentSupportNetworkInformationRecord(
+          await service.getListIncidentSupportNetworkInformationRecord(
             idPathParams,
             res,
             filterQueryParams,
@@ -115,6 +128,40 @@ describe('IncidentsService', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedSupportNetworkEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleIncidentSupportNetworkInformationRecord tests', () => {
+    it.each([
+      [
+        SupportNetworkSingleResponseIncidentExample,
+        {
+          [idName]: 'test',
+          [supportNetworkIdName]: 'test2',
+        } as SupportNetworkIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams) => {
+        const supportNetworkSpy = jest
+          .spyOn(
+            supportNetworkService,
+            'getSingleSupportNetworkInformationRecord',
+          )
+          .mockReturnValueOnce(Promise.resolve(new SupportNetworkEntity(data)));
+
+        const result =
+          await service.getSingleIncidentSupportNetworkInformationRecord(
+            idPathParams,
+            res,
+          );
+        expect(supportNetworkSpy).toHaveBeenCalledWith(
+          RecordType.Incident,
+          idPathParams,
+          res,
+        );
+        expect(result).toEqual(new SupportNetworkEntity(data));
       },
     );
   });
@@ -164,11 +211,23 @@ describe('IncidentsService', () => {
           [idName]: 'test',
           [attachmentIdName]: 'attachmenttest',
         } as AttachmentIdPathParams,
-        { [sinceParamName]: '2024-12-01' } as FilterQueryParams,
+        { [sinceParamName]: '2024-12-01' } as AttachmentDetailsQueryParams,
+        incidentsAttachmentsFieldName,
+      ],
+      [
+        AttachmentsSingleResponseIncidentExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        {
+          [sinceParamName]: '2024-12-01',
+          [inlineAttachmentParamName]: 'false',
+        } as AttachmentDetailsQueryParams,
         incidentsAttachmentsFieldName,
       ],
     ])(
-      'should return nested values given good input',
+      'should return single values given good input',
       async (data, idPathParams, filterQueryParams, typeFieldName) => {
         const attachmentsSpy = jest
           .spyOn(attachmentsService, 'getSingleAttachmentDetailsRecord')
@@ -193,7 +252,7 @@ describe('IncidentsService', () => {
     );
   });
 
-  describe('getSingleIncidentContactRecord tests', () => {
+  describe('getListIncidentContactRecord tests', () => {
     it.each([
       [
         ContactsListResponseIncidentExample,
@@ -207,10 +266,10 @@ describe('IncidentsService', () => {
       'should return nested values given good input',
       async (data, idPathParams, filterQueryParams) => {
         const contactsSpy = jest
-          .spyOn(contactsService, 'getSingleContactRecord')
+          .spyOn(contactsService, 'getListContactRecord')
           .mockReturnValueOnce(Promise.resolve(new NestedContactsEntity(data)));
 
-        const result = await service.getSingleIncidentContactRecord(
+        const result = await service.getListIncidentContactRecord(
           idPathParams,
           res,
           filterQueryParams,
@@ -222,6 +281,33 @@ describe('IncidentsService', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleIncidentContactRecord tests', () => {
+    it.each([
+      [
+        ContactsSingleResponseIncidentExample,
+        { [idName]: 'test', [contactIdName]: 'false' } as ContactIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams) => {
+        const contactsSpy = jest
+          .spyOn(contactsService, 'getSingleContactRecord')
+          .mockReturnValueOnce(Promise.resolve(new ContactsEntity(data)));
+
+        const result = await service.getSingleIncidentContactRecord(
+          idPathParams,
+          res,
+        );
+        expect(contactsSpy).toHaveBeenCalledWith(
+          RecordType.Incident,
+          idPathParams,
+          res,
+        );
+        expect(result).toEqual(new ContactsEntity(data));
       },
     );
   });

--- a/src/controllers/incidents/incidents.service.ts
+++ b/src/controllers/incidents/incidents.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { SupportNetworkService } from '../../helpers/support-network/support-network.service';
 import { RecordType } from '../../common/constants/enumerations';
-import { NestedSupportNetworkEntity } from '../../entities/support-network.entity';
+import {
+  NestedSupportNetworkEntity,
+  SupportNetworkEntity,
+} from '../../entities/support-network.entity';
 import {
   AttachmentIdPathParams,
   IdPathParams,
@@ -29,7 +32,7 @@ export class IncidentsService {
     id: IdPathParams,
     res: Response,
     filter?: FilterQueryParams,
-  ): Promise<NestedSupportNetworkEntity> {
+  ): Promise<SupportNetworkEntity | NestedSupportNetworkEntity> {
     return await this.supportNetworkService.getSingleSupportNetworkInformationRecord(
       RecordType.Incident,
       id,

--- a/src/controllers/incidents/incidents.service.ts
+++ b/src/controllers/incidents/incidents.service.ts
@@ -7,7 +7,9 @@ import {
 } from '../../entities/support-network.entity';
 import {
   AttachmentIdPathParams,
+  ContactIdPathParams,
   IdPathParams,
+  SupportNetworkIdPathParams,
 } from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
@@ -17,7 +19,10 @@ import {
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import { Response } from 'express';
-import { NestedContactsEntity } from '../../entities/contacts.entity';
+import {
+  ContactsEntity,
+  NestedContactsEntity,
+} from '../../entities/contacts.entity';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
 
 @Injectable()
@@ -29,11 +34,22 @@ export class IncidentsService {
   ) {}
 
   async getSingleIncidentSupportNetworkInformationRecord(
+    id: SupportNetworkIdPathParams,
+    res: Response,
+  ): Promise<SupportNetworkEntity> {
+    return await this.supportNetworkService.getSingleSupportNetworkInformationRecord(
+      RecordType.Incident,
+      id,
+      res,
+    );
+  }
+
+  async getListIncidentSupportNetworkInformationRecord(
     id: IdPathParams,
     res: Response,
     filter?: FilterQueryParams,
-  ): Promise<SupportNetworkEntity | NestedSupportNetworkEntity> {
-    return await this.supportNetworkService.getSingleSupportNetworkInformationRecord(
+  ): Promise<NestedSupportNetworkEntity> {
+    return await this.supportNetworkService.getListSupportNetworkInformationRecord(
       RecordType.Incident,
       id,
       res,
@@ -70,11 +86,22 @@ export class IncidentsService {
   }
 
   async getSingleIncidentContactRecord(
+    id: ContactIdPathParams,
+    res: Response,
+  ): Promise<ContactsEntity> {
+    return await this.contactsService.getSingleContactRecord(
+      RecordType.Incident,
+      id,
+      res,
+    );
+  }
+
+  async getListIncidentContactRecord(
     id: IdPathParams,
     res: Response,
     filter?: FilterQueryParams,
   ): Promise<NestedContactsEntity> {
-    return await this.contactsService.getSingleContactRecord(
+    return await this.contactsService.getListContactRecord(
       RecordType.Incident,
       id,
       res,

--- a/src/controllers/incidents/incidents.service.ts
+++ b/src/controllers/incidents/incidents.service.ts
@@ -11,7 +11,10 @@ import {
   IdPathParams,
   SupportNetworkIdPathParams,
 } from '../../dto/id-path-params.dto';
-import { FilterQueryParams } from '../../dto/filter-query-params.dto';
+import {
+  AttachmentDetailsQueryParams,
+  FilterQueryParams,
+} from '../../dto/filter-query-params.dto';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import { incidentsAttachmentsFieldName } from '../../common/constants/parameter-constants';
 import {
@@ -74,7 +77,7 @@ export class IncidentsService {
   async getSingleIncidentAttachmentDetailsRecord(
     id: AttachmentIdPathParams,
     res: Response,
-    filter?: FilterQueryParams,
+    filter?: AttachmentDetailsQueryParams,
   ): Promise<AttachmentDetailsEntity> {
     return await this.attachmentsService.getSingleAttachmentDetailsRecord(
       RecordType.Incident,

--- a/src/controllers/memos/memos.controller.spec.ts
+++ b/src/controllers/memos/memos.controller.spec.ts
@@ -10,18 +10,25 @@ import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import { MemosService } from './memos.service';
 import {
   attachmentIdName,
+  contactIdName,
   idName,
+  inlineAttachmentParamName,
   sinceParamName,
 } from '../../common/constants/parameter-constants';
 import {
   AttachmentIdPathParams,
+  ContactIdPathParams,
   IdPathParams,
 } from '../../dto/id-path-params.dto';
-import { FilterQueryParams } from '../../dto/filter-query-params.dto';
+import {
+  AttachmentDetailsQueryParams,
+  FilterQueryParams,
+} from '../../dto/filter-query-params.dto';
 import {
   AttachmentDetailsEntity,
   AttachmentDetailsMemoExample,
   AttachmentsListResponseMemoExample,
+  AttachmentsSingleResponseMemoExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import { getMockRes } from '@jest-mock/express';
@@ -29,6 +36,7 @@ import { startRowNumParamName } from '../../common/constants/upstream-constants'
 import configuration from '../../configuration/configuration';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
 import {
+  ContactsEntity,
   ContactsListResponseMemoExample,
   NestedContactsEntity,
 } from '../../entities/contacts.entity';
@@ -109,10 +117,22 @@ describe('MemosController', () => {
         {
           [sinceParamName]: '2020-02-02',
           [startRowNumParamName]: 0,
-        } as FilterQueryParams,
+        } as AttachmentDetailsQueryParams,
+      ],
+      [
+        AttachmentsSingleResponseMemoExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        {
+          [sinceParamName]: '2020-02-02',
+          [startRowNumParamName]: 0,
+          [inlineAttachmentParamName]: 'false',
+        } as AttachmentDetailsQueryParams,
       ],
     ])(
-      'should return nested values given good input',
+      'should return single values given good input',
       async (data, idPathParams, filterQueryParams) => {
         const memoServiceSpy = jest
           .spyOn(memosService, 'getSingleMemoAttachmentDetailsRecord')
@@ -135,7 +155,7 @@ describe('MemosController', () => {
     );
   });
 
-  describe('getSingleMemoContactRecord tests', () => {
+  describe('getListMemoContactRecord tests', () => {
     it.each([
       [
         ContactsListResponseMemoExample,
@@ -149,10 +169,10 @@ describe('MemosController', () => {
       'should return nested values given good input',
       async (data, idPathParams, filterQueryParams) => {
         const memoServiceSpy = jest
-          .spyOn(memosService, 'getSingleMemoContactRecord')
+          .spyOn(memosService, 'getListMemoContactRecord')
           .mockReturnValueOnce(Promise.resolve(new NestedContactsEntity(data)));
 
-        const result = await controller.getSingleMemoContactRecord(
+        const result = await controller.getListMemoContactRecord(
           idPathParams,
           res,
           filterQueryParams,
@@ -163,6 +183,29 @@ describe('MemosController', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleMemoContactRecord tests', () => {
+    it.each([
+      [
+        ContactsListResponseMemoExample,
+        { [idName]: 'test', [contactIdName]: 'test2' } as ContactIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams) => {
+        const memoServiceSpy = jest
+          .spyOn(memosService, 'getSingleMemoContactRecord')
+          .mockReturnValueOnce(Promise.resolve(new ContactsEntity(data)));
+
+        const result = await controller.getSingleMemoContactRecord(
+          idPathParams,
+          res,
+        );
+        expect(memoServiceSpy).toHaveBeenCalledWith(idPathParams, res);
+        expect(result).toEqual(new ContactsEntity(data));
       },
     );
   });

--- a/src/controllers/memos/memos.controller.ts
+++ b/src/controllers/memos/memos.controller.ts
@@ -29,18 +29,23 @@ import {
   sinceParamName,
   attachmentIdName,
   contactIdName,
+  inlineAttachmentParamName,
 } from '../../common/constants/parameter-constants';
 import {
   AttachmentIdPathParams,
   ContactIdPathParams,
   IdPathParams,
 } from '../../dto/id-path-params.dto';
-import { FilterQueryParams } from '../../dto/filter-query-params.dto';
+import {
+  AttachmentDetailsQueryParams,
+  FilterQueryParams,
+} from '../../dto/filter-query-params.dto';
 import {
   NestedAttachmentsEntity,
   AttachmentsListResponseMemoExample,
   AttachmentDetailsEntity,
   AttachmentDetailsMemoExample,
+  AttachmentsSingleResponseMemoExample,
 } from '../../entities/attachments.entity';
 import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
 import { Response } from 'express';
@@ -139,6 +144,7 @@ export class MemosController {
   @ApiQuery({ name: recordCountNeededParamName, required: false })
   @ApiQuery({ name: pageSizeParamName, required: false })
   @ApiQuery({ name: startRowNumParamName, required: false })
+  @ApiQuery({ name: inlineAttachmentParamName, required: false })
   @ApiExtraModels(AttachmentDetailsEntity)
   @ApiOkResponse({
     headers: totalRecordCountHeadersSwagger,
@@ -148,8 +154,11 @@ export class MemosController {
           $ref: getSchemaPath(AttachmentDetailsEntity),
         },
         examples: {
-          AttachmentDetailsResponse: {
+          AttachmentDetailsDownloadResponse: {
             value: AttachmentDetailsMemoExample,
+          },
+          AttachmentDetailsNoDownloadResponse: {
+            value: AttachmentsSingleResponseMemoExample,
           },
         },
       },
@@ -173,7 +182,7 @@ export class MemosController {
         skipMissingProperties: true,
       }),
     )
-    filter?: FilterQueryParams,
+    filter?: AttachmentDetailsQueryParams,
   ): Promise<AttachmentDetailsEntity> {
     return await this.memosService.getSingleMemoAttachmentDetailsRecord(
       id,

--- a/src/controllers/memos/memos.controller.ts
+++ b/src/controllers/memos/memos.controller.ts
@@ -28,9 +28,11 @@ import {
   CONTENT_TYPE,
   sinceParamName,
   attachmentIdName,
+  contactIdName,
 } from '../../common/constants/parameter-constants';
 import {
   AttachmentIdPathParams,
+  ContactIdPathParams,
   IdPathParams,
 } from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
@@ -55,6 +57,8 @@ import {
 import {
   NestedContactsEntity,
   ContactsListResponseMemoExample,
+  ContactsEntity,
+  ContactsSingleResponseMemoExample,
 } from '../../entities/contacts.entity';
 import { ApiForbiddenErrorEntity } from '../../entities/api-forbidden-error.entity';
 import { ApiUnauthorizedErrorEntity } from '../../entities/api-unauthorized-error.entity';
@@ -197,14 +201,14 @@ export class MemosController {
           $ref: getSchemaPath(NestedContactsEntity),
         },
         examples: {
-          ContactsResponse: {
+          ContactsListResponse: {
             value: ContactsListResponseMemoExample,
           },
         },
       },
     },
   })
-  async getSingleMemoContactRecord(
+  async getListMemoContactRecord(
     @Param(
       new ValidationPipe({
         transform: true,
@@ -224,6 +228,40 @@ export class MemosController {
     )
     filter?: FilterQueryParams,
   ): Promise<NestedContactsEntity> {
-    return await this.memosService.getSingleMemoContactRecord(id, res, filter);
+    return await this.memosService.getListMemoContactRecord(id, res, filter);
+  }
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Get(`:${idName}/contacts/:${contactIdName}`)
+  @ApiOperation({
+    description: `Displays the single ${contactIdName} result if it is related to the given Memo id.`,
+  })
+  @ApiExtraModels(ContactsEntity)
+  @ApiOkResponse({
+    content: {
+      [CONTENT_TYPE]: {
+        schema: {
+          $ref: getSchemaPath(ContactsEntity),
+        },
+        examples: {
+          ContactsSingleResponse: {
+            value: ContactsSingleResponseMemoExample,
+          },
+        },
+      },
+    },
+  })
+  async getSingleMemoContactRecord(
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: ContactIdPathParams,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<ContactsEntity> {
+    return await this.memosService.getSingleMemoContactRecord(id, res);
   }
 }

--- a/src/controllers/memos/memos.service.spec.ts
+++ b/src/controllers/memos/memos.service.spec.ts
@@ -11,26 +11,35 @@ import {
   AttachmentDetailsEntity,
   AttachmentDetailsMemoExample,
   AttachmentsListResponseMemoExample,
+  AttachmentsSingleResponseMemoExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import { RecordType } from '../../common/constants/enumerations';
 import {
   attachmentIdName,
+  contactIdName,
   idName,
+  inlineAttachmentParamName,
   memoAttachmentsFieldName,
   sinceParamName,
 } from '../../common/constants/parameter-constants';
 import {
   AttachmentIdPathParams,
+  ContactIdPathParams,
   IdPathParams,
 } from '../../dto/id-path-params.dto';
-import { FilterQueryParams } from '../../dto/filter-query-params.dto';
+import {
+  AttachmentDetailsQueryParams,
+  FilterQueryParams,
+} from '../../dto/filter-query-params.dto';
 import { getMockRes } from '@jest-mock/express';
 import { startRowNumParamName } from '../../common/constants/upstream-constants';
 import configuration from '../../configuration/configuration';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
 import {
+  ContactsEntity,
   ContactsListResponseMemoExample,
+  ContactsSingleResponseMemoExample,
   NestedContactsEntity,
 } from '../../entities/contacts.entity';
 
@@ -108,7 +117,7 @@ describe('MemosService', () => {
     );
   });
 
-  describe('getSinglememoAttachmentDetailsRecord tests', () => {
+  describe('getSingleMemoAttachmentDetailsRecord tests', () => {
     it.each([
       [
         AttachmentDetailsMemoExample,
@@ -116,11 +125,23 @@ describe('MemosService', () => {
           [idName]: 'test',
           [attachmentIdName]: 'attachmenttest',
         } as AttachmentIdPathParams,
-        { [sinceParamName]: '2024-12-01' } as FilterQueryParams,
+        { [sinceParamName]: '2024-12-01' } as AttachmentDetailsQueryParams,
+        memoAttachmentsFieldName,
+      ],
+      [
+        AttachmentsSingleResponseMemoExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        {
+          [sinceParamName]: '2024-12-01',
+          [inlineAttachmentParamName]: 'false',
+        } as AttachmentDetailsQueryParams,
         memoAttachmentsFieldName,
       ],
     ])(
-      'should return nested values given good input',
+      'should return single values given good input',
       async (data, idPathParams, filterQueryParams, typeFieldName) => {
         const attachmentsSpy = jest
           .spyOn(attachmentsService, 'getSingleAttachmentDetailsRecord')
@@ -145,7 +166,7 @@ describe('MemosService', () => {
     );
   });
 
-  describe('getSingleMemoContactRecord tests', () => {
+  describe('getListMemoContactRecord tests', () => {
     it.each([
       [
         ContactsListResponseMemoExample,
@@ -159,10 +180,10 @@ describe('MemosService', () => {
       'should return nested values given good input',
       async (data, idPathParams, filterQueryParams) => {
         const contactsSpy = jest
-          .spyOn(contactsService, 'getSingleContactRecord')
+          .spyOn(contactsService, 'getListContactRecord')
           .mockReturnValueOnce(Promise.resolve(new NestedContactsEntity(data)));
 
-        const result = await service.getSingleMemoContactRecord(
+        const result = await service.getListMemoContactRecord(
           idPathParams,
           res,
           filterQueryParams,
@@ -174,6 +195,33 @@ describe('MemosService', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleMemoContactRecord tests', () => {
+    it.each([
+      [
+        ContactsSingleResponseMemoExample,
+        { [idName]: 'test', [contactIdName]: 'test2' } as ContactIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams) => {
+        const contactsSpy = jest
+          .spyOn(contactsService, 'getSingleContactRecord')
+          .mockReturnValueOnce(Promise.resolve(new ContactsEntity(data)));
+
+        const result = await service.getSingleMemoContactRecord(
+          idPathParams,
+          res,
+        );
+        expect(contactsSpy).toHaveBeenCalledWith(
+          RecordType.Memo,
+          idPathParams,
+          res,
+        );
+        expect(result).toEqual(new ContactsEntity(data));
       },
     );
   });

--- a/src/controllers/memos/memos.service.ts
+++ b/src/controllers/memos/memos.service.ts
@@ -3,6 +3,7 @@ import { RecordType } from '../../common/constants/enumerations';
 import { memoAttachmentsFieldName } from '../../common/constants/parameter-constants';
 import {
   AttachmentIdPathParams,
+  ContactIdPathParams,
   IdPathParams,
 } from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
@@ -13,7 +14,10 @@ import {
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import { Response } from 'express';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
-import { NestedContactsEntity } from '../../entities/contacts.entity';
+import {
+  ContactsEntity,
+  NestedContactsEntity,
+} from '../../entities/contacts.entity';
 
 @Injectable()
 export class MemosService {
@@ -51,11 +55,22 @@ export class MemosService {
   }
 
   async getSingleMemoContactRecord(
+    id: ContactIdPathParams,
+    res: Response,
+  ): Promise<ContactsEntity> {
+    return await this.contactsService.getSingleContactRecord(
+      RecordType.Memo,
+      id,
+      res,
+    );
+  }
+
+  async getListMemoContactRecord(
     id: IdPathParams,
     res: Response,
     filter?: FilterQueryParams,
   ): Promise<NestedContactsEntity> {
-    return await this.contactsService.getSingleContactRecord(
+    return await this.contactsService.getListContactRecord(
       RecordType.Memo,
       id,
       res,

--- a/src/controllers/memos/memos.service.ts
+++ b/src/controllers/memos/memos.service.ts
@@ -6,7 +6,10 @@ import {
   ContactIdPathParams,
   IdPathParams,
 } from '../../dto/id-path-params.dto';
-import { FilterQueryParams } from '../../dto/filter-query-params.dto';
+import {
+  AttachmentDetailsQueryParams,
+  FilterQueryParams,
+} from '../../dto/filter-query-params.dto';
 import {
   AttachmentDetailsEntity,
   NestedAttachmentsEntity,
@@ -43,7 +46,7 @@ export class MemosService {
   async getSingleMemoAttachmentDetailsRecord(
     id: AttachmentIdPathParams,
     res: Response,
-    filter?: FilterQueryParams,
+    filter?: AttachmentDetailsQueryParams,
   ): Promise<AttachmentDetailsEntity> {
     return await this.attachmentsService.getSingleAttachmentDetailsRecord(
       RecordType.Memo,

--- a/src/controllers/service-requests/service-requests.controller.spec.ts
+++ b/src/controllers/service-requests/service-requests.controller.spec.ts
@@ -6,27 +6,38 @@ import { ServiceRequestsController } from './service-requests.controller';
 import { ServiceRequestsService } from './service-requests.service';
 import {
   NestedSupportNetworkEntity,
+  SupportNetworkEntity,
   SupportNetworkListResponseSRExample,
+  SupportNetworkSingleResponseSRExample,
 } from '../../entities/support-network.entity';
 import {
   AttachmentIdPathParams,
+  ContactIdPathParams,
   IdPathParams,
+  SupportNetworkIdPathParams,
 } from '../../dto/id-path-params.dto';
-import { FilterQueryParams } from '../../dto/filter-query-params.dto';
+import {
+  AttachmentDetailsQueryParams,
+  FilterQueryParams,
+} from '../../dto/filter-query-params.dto';
 import { SupportNetworkService } from '../../helpers/support-network/support-network.service';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import {
   attachmentIdName,
+  contactIdName,
   idName,
+  inlineAttachmentParamName,
   sinceParamName,
+  supportNetworkIdName,
 } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import {
   AttachmentDetailsEntity,
   AttachmentDetailsSRExample,
   AttachmentsListResponseSRExample,
+  AttachmentsSingleResponseSRExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import { AuthService } from '../../common/guards/auth/auth.service';
@@ -35,7 +46,9 @@ import { startRowNumParamName } from '../../common/constants/upstream-constants'
 import configuration from '../../configuration/configuration';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
 import {
+  ContactsEntity,
   ContactsListResponseSRExample,
+  ContactsSingleResponseSRExample,
   NestedContactsEntity,
 } from '../../entities/contacts.entity';
 
@@ -76,7 +89,7 @@ describe('ServiceRequestsController', () => {
     expect(controller).toBeDefined();
   });
 
-  describe('getSingleSRSupportNetworkInformationRecord tests', () => {
+  describe('getListSRSupportNetworkInformationRecord tests', () => {
     it.each([
       [
         SupportNetworkListResponseSRExample,
@@ -92,14 +105,14 @@ describe('ServiceRequestsController', () => {
         const SRsServiceSpy = jest
           .spyOn(
             serviceRequestsService,
-            'getSingleSRSupportNetworkInformationRecord',
+            'getListSRSupportNetworkInformationRecord',
           )
           .mockReturnValueOnce(
             Promise.resolve(new NestedSupportNetworkEntity(data)),
           );
 
         const result =
-          await controller.getSingleSRSupportNetworkInformationRecord(
+          await controller.getListSRSupportNetworkInformationRecord(
             idPathParams,
             res,
             filterQueryParams,
@@ -110,6 +123,36 @@ describe('ServiceRequestsController', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedSupportNetworkEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleSRSupportNetworkInformationRecord tests', () => {
+    it.each([
+      [
+        SupportNetworkSingleResponseSRExample,
+        {
+          [idName]: 'test',
+          [supportNetworkIdName]: 'test2',
+        } as SupportNetworkIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams) => {
+        const SRsServiceSpy = jest
+          .spyOn(
+            serviceRequestsService,
+            'getSingleSRSupportNetworkInformationRecord',
+          )
+          .mockReturnValueOnce(Promise.resolve(new SupportNetworkEntity(data)));
+
+        const result =
+          await controller.getSingleSRSupportNetworkInformationRecord(
+            idPathParams,
+            res,
+          );
+        expect(SRsServiceSpy).toHaveBeenCalledWith(idPathParams, res);
+        expect(result).toEqual(new SupportNetworkEntity(data));
       },
     );
   });
@@ -159,10 +202,22 @@ describe('ServiceRequestsController', () => {
         {
           [sinceParamName]: '2020-02-02',
           [startRowNumParamName]: 0,
-        } as FilterQueryParams,
+        } as AttachmentDetailsQueryParams,
+      ],
+      [
+        AttachmentsSingleResponseSRExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        {
+          [sinceParamName]: '2020-02-02',
+          [startRowNumParamName]: 0,
+          [inlineAttachmentParamName]: 'false',
+        } as AttachmentDetailsQueryParams,
       ],
     ])(
-      'should return nested values given good input',
+      'should return single values given good input',
       async (data, idPathParams, filterQueryParams) => {
         const SRsServiceSpy = jest
           .spyOn(serviceRequestsService, 'getSingleSRAttachmentDetailsRecord')
@@ -185,7 +240,7 @@ describe('ServiceRequestsController', () => {
     );
   });
 
-  describe('getSingleSRContactRecord tests', () => {
+  describe('getListSRContactRecord tests', () => {
     it.each([
       [
         ContactsListResponseSRExample,
@@ -199,10 +254,10 @@ describe('ServiceRequestsController', () => {
       'should return nested values given good input',
       async (data, idPathParams, filterQueryParams) => {
         const SRsServiceSpy = jest
-          .spyOn(serviceRequestsService, 'getSingleSRContactRecord')
+          .spyOn(serviceRequestsService, 'getListSRContactRecord')
           .mockReturnValueOnce(Promise.resolve(new NestedContactsEntity(data)));
 
-        const result = await controller.getSingleSRContactRecord(
+        const result = await controller.getListSRContactRecord(
           idPathParams,
           res,
           filterQueryParams,
@@ -213,6 +268,33 @@ describe('ServiceRequestsController', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleSRContactRecord tests', () => {
+    it.each([
+      [
+        ContactsSingleResponseSRExample,
+        { [idName]: 'test', [contactIdName]: 'test2' } as ContactIdPathParams,
+        {
+          [sinceParamName]: '2020-02-02',
+          [startRowNumParamName]: 0,
+        } as FilterQueryParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams) => {
+        const SRsServiceSpy = jest
+          .spyOn(serviceRequestsService, 'getSingleSRContactRecord')
+          .mockReturnValueOnce(Promise.resolve(new ContactsEntity(data)));
+
+        const result = await controller.getSingleSRContactRecord(
+          idPathParams,
+          res,
+        );
+        expect(SRsServiceSpy).toHaveBeenCalledWith(idPathParams, res);
+        expect(result).toEqual(new ContactsEntity(data));
       },
     );
   });

--- a/src/controllers/service-requests/service-requests.controller.ts
+++ b/src/controllers/service-requests/service-requests.controller.ts
@@ -54,6 +54,7 @@ import {
   AttachmentDetailsEntity,
   AttachmentDetailsSRExample,
   AttachmentsListResponseSRExample,
+  AttachmentsSingleResponseSRExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import { AuthGuard } from '../../common/guards/auth/auth.guard';
@@ -253,8 +254,11 @@ export class ServiceRequestsController {
           $ref: getSchemaPath(AttachmentDetailsEntity),
         },
         examples: {
-          AttachmentDetailsResponse: {
+          AttachmentDetailsDownloadResponse: {
             value: AttachmentDetailsSRExample,
+          },
+          AttachmentDetailsNoDownloadResponse: {
+            value: AttachmentsSingleResponseSRExample,
           },
         },
       },

--- a/src/controllers/service-requests/service-requests.controller.ts
+++ b/src/controllers/service-requests/service-requests.controller.ts
@@ -26,11 +26,14 @@ import {
 import { ServiceRequestsService } from './service-requests.service';
 import {
   NestedSupportNetworkEntity,
+  SupportNetworkEntity,
   SupportNetworkListResponseSRExample,
+  SupportNetworkSingleResponseSRExample,
 } from '../../entities/support-network.entity';
 import {
   AttachmentIdPathParams,
   IdPathParams,
+  SupportNetworkIdPathParams,
 } from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import {
@@ -38,6 +41,7 @@ import {
   CONTENT_TYPE,
   idName,
   sinceParamName,
+  supportNetworkIdName,
 } from '../../common/constants/parameter-constants';
 import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
 import {
@@ -80,25 +84,32 @@ export class ServiceRequestsController {
   constructor(private readonly serviceRequestService: ServiceRequestsService) {}
 
   @UseInterceptors(ClassSerializerInterceptor)
-  @Get(`:${idName}/support-network`)
+  @Get(`:${idName}/support-network/:${supportNetworkIdName}?`)
   @ApiOperation({
     description:
-      'Find all Support Network entries related to a given Service Request entity by Service Request id.',
+      `Find all Support Network entries related to a given Service Request entity by Service Request id. Optionally, if` +
+      ` ${supportNetworkIdName} is given, will display that single result if it is related to the given Service Request id.`,
   })
   @ApiQuery({ name: sinceParamName, required: false })
   @ApiQuery({ name: recordCountNeededParamName, required: false })
   @ApiQuery({ name: pageSizeParamName, required: false })
   @ApiQuery({ name: startRowNumParamName, required: false })
-  @ApiExtraModels(NestedSupportNetworkEntity)
+  @ApiExtraModels(SupportNetworkEntity, NestedSupportNetworkEntity)
   @ApiOkResponse({
     headers: totalRecordCountHeadersSwagger,
     content: {
       [CONTENT_TYPE]: {
         schema: {
-          $ref: getSchemaPath(NestedSupportNetworkEntity),
+          oneOf: [
+            { $ref: getSchemaPath(SupportNetworkEntity) },
+            { $ref: getSchemaPath(NestedSupportNetworkEntity) },
+          ],
         },
         examples: {
-          SupportNetworkResponse: {
+          SupportNetworkSingleResponse: {
+            value: SupportNetworkSingleResponseSRExample,
+          },
+          SupportNetworkListResponse: {
             value: SupportNetworkListResponseSRExample,
           },
         },
@@ -113,7 +124,7 @@ export class ServiceRequestsController {
         forbidNonWhitelisted: true,
       }),
     )
-    id: IdPathParams,
+    id: SupportNetworkIdPathParams,
     @Res({ passthrough: true }) res: Response,
     @Query(
       new ValidationPipe({
@@ -124,7 +135,7 @@ export class ServiceRequestsController {
       }),
     )
     filter?: FilterQueryParams,
-  ): Promise<NestedSupportNetworkEntity> {
+  ): Promise<SupportNetworkEntity | NestedSupportNetworkEntity> {
     return await this.serviceRequestService.getSingleSRSupportNetworkInformationRecord(
       id,
       res,

--- a/src/controllers/service-requests/service-requests.service.spec.ts
+++ b/src/controllers/service-requests/service-requests.service.spec.ts
@@ -7,27 +7,38 @@ import { SupportNetworkService } from '../../helpers/support-network/support-net
 import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import {
   NestedSupportNetworkEntity,
+  SupportNetworkEntity,
   SupportNetworkListResponseSRExample,
+  SupportNetworkSingleResponseSRExample,
 } from '../../entities/support-network.entity';
 import { RecordType } from '../../common/constants/enumerations';
 import {
   AttachmentIdPathParams,
+  ContactIdPathParams,
   IdPathParams,
+  SupportNetworkIdPathParams,
 } from '../../dto/id-path-params.dto';
-import { FilterQueryParams } from '../../dto/filter-query-params.dto';
+import {
+  AttachmentDetailsQueryParams,
+  FilterQueryParams,
+} from '../../dto/filter-query-params.dto';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import {
   attachmentIdName,
+  contactIdName,
   idName,
+  inlineAttachmentParamName,
   sinceParamName,
   srAttachmentsFieldName,
+  supportNetworkIdName,
 } from '../../common/constants/parameter-constants';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import {
   AttachmentDetailsEntity,
   AttachmentDetailsSRExample,
   AttachmentsListResponseSRExample,
+  AttachmentsSingleResponseSRExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import { getMockRes } from '@jest-mock/express';
@@ -35,7 +46,9 @@ import { startRowNumParamName } from '../../common/constants/upstream-constants'
 import configuration from '../../configuration/configuration';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
 import {
+  ContactsEntity,
   ContactsListResponseSRExample,
+  ContactsSingleResponseSRExample,
   NestedContactsEntity,
 } from '../../entities/contacts.entity';
 
@@ -81,7 +94,7 @@ describe('ServiceRequestsService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('getSingleSRSupportNetworkInformationRecord tests', () => {
+  describe('getListSRSupportNetworkInformationRecord tests', () => {
     it.each([
       [
         SupportNetworkListResponseSRExample,
@@ -97,13 +110,13 @@ describe('ServiceRequestsService', () => {
         const supportNetworkSpy = jest
           .spyOn(
             supportNetworkService,
-            'getSingleSupportNetworkInformationRecord',
+            'getListSupportNetworkInformationRecord',
           )
           .mockReturnValueOnce(
             Promise.resolve(new NestedSupportNetworkEntity(data)),
           );
 
-        const result = await service.getSingleSRSupportNetworkInformationRecord(
+        const result = await service.getListSRSupportNetworkInformationRecord(
           idPathParams,
           res,
           filterQueryParams,
@@ -115,6 +128,39 @@ describe('ServiceRequestsService', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedSupportNetworkEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleSRSupportNetworkInformationRecord tests', () => {
+    it.each([
+      [
+        SupportNetworkSingleResponseSRExample,
+        {
+          [idName]: 'test',
+          [supportNetworkIdName]: 'test2',
+        } as SupportNetworkIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams) => {
+        const supportNetworkSpy = jest
+          .spyOn(
+            supportNetworkService,
+            'getSingleSupportNetworkInformationRecord',
+          )
+          .mockReturnValueOnce(Promise.resolve(new SupportNetworkEntity(data)));
+
+        const result = await service.getSingleSRSupportNetworkInformationRecord(
+          idPathParams,
+          res,
+        );
+        expect(supportNetworkSpy).toHaveBeenCalledWith(
+          RecordType.SR,
+          idPathParams,
+          res,
+        );
+        expect(result).toEqual(new SupportNetworkEntity(data));
       },
     );
   });
@@ -164,11 +210,23 @@ describe('ServiceRequestsService', () => {
           [idName]: 'test',
           [attachmentIdName]: 'attachmenttest',
         } as AttachmentIdPathParams,
-        { [sinceParamName]: '2024-12-01' } as FilterQueryParams,
+        { [sinceParamName]: '2024-12-01' } as AttachmentDetailsQueryParams,
+        srAttachmentsFieldName,
+      ],
+      [
+        AttachmentsSingleResponseSRExample,
+        {
+          [idName]: 'test',
+          [attachmentIdName]: 'attachmenttest',
+        } as AttachmentIdPathParams,
+        {
+          [sinceParamName]: '2024-12-01',
+          [inlineAttachmentParamName]: 'false',
+        } as AttachmentDetailsQueryParams,
         srAttachmentsFieldName,
       ],
     ])(
-      'should return nested values given good input',
+      'should return single values given good input',
       async (data, idPathParams, filterQueryParams, typeFieldName) => {
         const attachmentsSpy = jest
           .spyOn(attachmentsService, 'getSingleAttachmentDetailsRecord')
@@ -193,7 +251,7 @@ describe('ServiceRequestsService', () => {
     );
   });
 
-  describe('getSingleSRContactRecord tests', () => {
+  describe('getListSRContactRecord tests', () => {
     it.each([
       [
         ContactsListResponseSRExample,
@@ -207,10 +265,10 @@ describe('ServiceRequestsService', () => {
       'should return nested values given good input',
       async (data, idPathParams, filterQueryParams) => {
         const contactsSpy = jest
-          .spyOn(contactsService, 'getSingleContactRecord')
+          .spyOn(contactsService, 'getListContactRecord')
           .mockReturnValueOnce(Promise.resolve(new NestedContactsEntity(data)));
 
-        const result = await service.getSingleSRContactRecord(
+        const result = await service.getListSRContactRecord(
           idPathParams,
           res,
           filterQueryParams,
@@ -222,6 +280,33 @@ describe('ServiceRequestsService', () => {
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleSRContactRecord tests', () => {
+    it.each([
+      [
+        ContactsSingleResponseSRExample,
+        { [idName]: 'test', [contactIdName]: 'test2' } as ContactIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, idPathParams) => {
+        const contactsSpy = jest
+          .spyOn(contactsService, 'getSingleContactRecord')
+          .mockReturnValueOnce(Promise.resolve(new ContactsEntity(data)));
+
+        const result = await service.getSingleSRContactRecord(
+          idPathParams,
+          res,
+        );
+        expect(contactsSpy).toHaveBeenCalledWith(
+          RecordType.SR,
+          idPathParams,
+          res,
+        );
+        expect(result).toEqual(new ContactsEntity(data));
       },
     );
   });

--- a/src/controllers/service-requests/service-requests.service.ts
+++ b/src/controllers/service-requests/service-requests.service.ts
@@ -7,9 +7,14 @@ import {
 } from '../../entities/support-network.entity';
 import {
   AttachmentIdPathParams,
+  ContactIdPathParams,
   IdPathParams,
+  SupportNetworkIdPathParams,
 } from '../../dto/id-path-params.dto';
-import { FilterQueryParams } from '../../dto/filter-query-params.dto';
+import {
+  AttachmentDetailsQueryParams,
+  FilterQueryParams,
+} from '../../dto/filter-query-params.dto';
 import { AttachmentsService } from '../../helpers/attachments/attachments.service';
 import { srAttachmentsFieldName } from '../../common/constants/parameter-constants';
 import {
@@ -17,7 +22,10 @@ import {
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import { Response } from 'express';
-import { NestedContactsEntity } from '../../entities/contacts.entity';
+import {
+  ContactsEntity,
+  NestedContactsEntity,
+} from '../../entities/contacts.entity';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
 
 @Injectable()
@@ -29,11 +37,22 @@ export class ServiceRequestsService {
   ) {}
 
   async getSingleSRSupportNetworkInformationRecord(
+    id: SupportNetworkIdPathParams,
+    res: Response,
+  ): Promise<SupportNetworkEntity> {
+    return await this.supportNetworkService.getSingleSupportNetworkInformationRecord(
+      RecordType.SR,
+      id,
+      res,
+    );
+  }
+
+  async getListSRSupportNetworkInformationRecord(
     id: IdPathParams,
     res: Response,
     filter?: FilterQueryParams,
-  ): Promise<SupportNetworkEntity | NestedSupportNetworkEntity> {
-    return await this.supportNetworkService.getSingleSupportNetworkInformationRecord(
+  ): Promise<NestedSupportNetworkEntity> {
+    return await this.supportNetworkService.getListSupportNetworkInformationRecord(
       RecordType.SR,
       id,
       res,
@@ -58,7 +77,7 @@ export class ServiceRequestsService {
   async getSingleSRAttachmentDetailsRecord(
     id: AttachmentIdPathParams,
     res: Response,
-    filter?: FilterQueryParams,
+    filter?: AttachmentDetailsQueryParams,
   ): Promise<AttachmentDetailsEntity> {
     return await this.attachmentsService.getSingleAttachmentDetailsRecord(
       RecordType.SR,
@@ -70,11 +89,22 @@ export class ServiceRequestsService {
   }
 
   async getSingleSRContactRecord(
+    id: ContactIdPathParams,
+    res: Response,
+  ): Promise<ContactsEntity> {
+    return await this.contactsService.getSingleContactRecord(
+      RecordType.SR,
+      id,
+      res,
+    );
+  }
+
+  async getListSRContactRecord(
     id: IdPathParams,
     res: Response,
     filter?: FilterQueryParams,
   ): Promise<NestedContactsEntity> {
-    return await this.contactsService.getSingleContactRecord(
+    return await this.contactsService.getListContactRecord(
       RecordType.SR,
       id,
       res,

--- a/src/controllers/service-requests/service-requests.service.ts
+++ b/src/controllers/service-requests/service-requests.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { SupportNetworkService } from '../../helpers/support-network/support-network.service';
 import { RecordType } from '../../common/constants/enumerations';
-import { NestedSupportNetworkEntity } from '../../entities/support-network.entity';
+import {
+  NestedSupportNetworkEntity,
+  SupportNetworkEntity,
+} from '../../entities/support-network.entity';
 import {
   AttachmentIdPathParams,
   IdPathParams,
@@ -29,7 +32,7 @@ export class ServiceRequestsService {
     id: IdPathParams,
     res: Response,
     filter?: FilterQueryParams,
-  ): Promise<NestedSupportNetworkEntity> {
+  ): Promise<SupportNetworkEntity | NestedSupportNetworkEntity> {
     return await this.supportNetworkService.getSingleSupportNetworkInformationRecord(
       RecordType.SR,
       id,

--- a/src/dto/filter-query-params.dto.ts
+++ b/src/dto/filter-query-params.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Exclude, Expose } from 'class-transformer';
 import {
+  IsBoolean,
   IsEnum,
   IsInt,
   IsISO8601,
@@ -19,7 +20,10 @@ import {
   startRowNumMin,
   startRowNumParamName,
 } from '../common/constants/upstream-constants';
-import { sinceParamName } from '../common/constants/parameter-constants';
+import {
+  inlineAttachmentParamName,
+  sinceParamName,
+} from '../common/constants/parameter-constants';
 
 @Exclude()
 export class FilterQueryParams {
@@ -81,4 +85,18 @@ export class FilterQueryParams {
       ` response header and PageSize parameter to enable pagination.`,
   })
   [startRowNumParamName]?: number;
+}
+
+@Exclude()
+export class AttachmentDetailsQueryParams extends FilterQueryParams {
+  @IsOptional()
+  @IsBoolean()
+  @Expose()
+  @ApiProperty({
+    example: true,
+    default: true,
+    description:
+      'Whether or not you want the inline attachment download to be included in the request.',
+  })
+  [inlineAttachmentParamName]?: boolean = true;
 }

--- a/src/dto/filter-query-params.dto.ts
+++ b/src/dto/filter-query-params.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Exclude, Expose } from 'class-transformer';
 import {
-  IsBoolean,
+  IsBooleanString,
   IsEnum,
   IsInt,
   IsISO8601,
@@ -90,13 +90,14 @@ export class FilterQueryParams {
 @Exclude()
 export class AttachmentDetailsQueryParams extends FilterQueryParams {
   @IsOptional()
-  @IsBoolean()
+  @IsBooleanString()
   @Expose()
   @ApiProperty({
     example: true,
     default: true,
+    type: 'boolean',
     description:
       'Whether or not you want the inline attachment download to be included in the request.',
   })
-  [inlineAttachmentParamName]?: boolean = true;
+  [inlineAttachmentParamName]?: string = 'true';
 }

--- a/src/dto/id-path-params.dto.ts
+++ b/src/dto/id-path-params.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, Matches } from 'class-validator';
+import { Matches } from 'class-validator';
 import {
   attachmentIdName,
   contactIdName,
@@ -44,7 +44,6 @@ export class ContactIdPathParams extends IdPathParams {
 }
 
 export class SupportNetworkIdPathParams extends IdPathParams {
-  @IsOptional()
   @Matches(idRegex)
   @ApiProperty({
     example: 'Support-Network-Id-Here',

--- a/src/dto/id-path-params.dto.ts
+++ b/src/dto/id-path-params.dto.ts
@@ -1,10 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Matches } from 'class-validator';
+import { IsOptional, Matches } from 'class-validator';
 import {
   attachmentIdName,
+  contactIdName,
   idMaxLength,
   idName,
   idRegex,
+  supportNetworkIdName,
+  visitIdName,
 } from '../common/constants/parameter-constants';
 
 export class IdPathParams {
@@ -27,4 +30,39 @@ export class AttachmentIdPathParams extends IdPathParams {
     pattern: idRegex.toString().replaceAll('/', ''),
   })
   [attachmentIdName]: string;
+}
+
+export class ContactIdPathParams extends IdPathParams {
+  @Matches(idRegex)
+  @ApiProperty({
+    example: 'Contact-Id-Here',
+    description: 'The Id of the contact you wish to find.',
+    maxLength: idMaxLength,
+    pattern: idRegex.toString().replaceAll('/', ''),
+  })
+  [contactIdName]: string;
+}
+
+export class SupportNetworkIdPathParams extends IdPathParams {
+  @IsOptional()
+  @Matches(idRegex)
+  @ApiProperty({
+    example: 'Support-Network-Id-Here',
+    description: 'The Id of the support network you wish to find.',
+    maxLength: idMaxLength,
+    pattern: idRegex.toString().replaceAll('/', ''),
+    required: false,
+  })
+  [supportNetworkIdName]?: string;
+}
+
+export class VisitIdPathParams extends IdPathParams {
+  @Matches(idRegex)
+  @ApiProperty({
+    example: 'Visit-Id-Here',
+    description: 'The Id of the visit you wish to find.',
+    maxLength: idMaxLength,
+    pattern: idRegex.toString().replaceAll('/', ''),
+  })
+  [visitIdName]: string;
 }

--- a/src/dto/id-path-params.dto.ts
+++ b/src/dto/id-path-params.dto.ts
@@ -51,9 +51,8 @@ export class SupportNetworkIdPathParams extends IdPathParams {
     description: 'The Id of the support network you wish to find.',
     maxLength: idMaxLength,
     pattern: idRegex.toString().replaceAll('/', ''),
-    required: false,
   })
-  [supportNetworkIdName]?: string;
+  [supportNetworkIdName]: string;
 }
 
 export class VisitIdPathParams extends IdPathParams {

--- a/src/entities/attachments.entity.ts
+++ b/src/entities/attachments.entity.ts
@@ -5,7 +5,7 @@ import { createdDateFieldName } from '../common/constants/upstream-constants';
 /*
  * Examples
  */
-const AttachmentsSingleResponseCaseExample = {
+export const AttachmentsSingleResponseCaseExample = {
   'Application No': '',
   Categorie: 'Attachment',
   Category: 'Assessment',
@@ -50,7 +50,7 @@ export const AttachmentDetailsCaseExample = {
   'Attachment Id': 'base64 inline attachment here',
 };
 
-const AttachmentsSingleResponseIncidentExample = {
+export const AttachmentsSingleResponseIncidentExample = {
   ...AttachmentsSingleResponseCaseExample,
   'No Intervention': '',
   'Case Id': '',
@@ -63,7 +63,7 @@ export const AttachmentDetailsIncidentExample = {
   'Attachment Id': 'base64 inline attachment here',
 };
 
-const AttachmentsSingleResponseSRExample = {
+export const AttachmentsSingleResponseSRExample = {
   ...AttachmentsSingleResponseCaseExample,
   'No Intervention': '',
   'Case Id': '',
@@ -76,7 +76,7 @@ export const AttachmentDetailsSRExample = {
   'Attachment Id': 'base64 inline attachment here',
 };
 
-const AttachmentsSingleResponseMemoExample = {
+export const AttachmentsSingleResponseMemoExample = {
   ...AttachmentsSingleResponseCaseExample,
   'No Intervention': '',
   'Case Id': '',
@@ -138,7 +138,7 @@ export const AttachmentsListResponseMemoExample = {
  */
 @Exclude()
 @ApiSchema({ name: 'Attachment' })
-class AttachmentsEntity {
+export class AttachmentsEntity {
   @ApiProperty({
     example: AttachmentsSingleResponseCaseExample['Name'],
   })

--- a/src/entities/attachments.entity.ts
+++ b/src/entities/attachments.entity.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 import { Exclude, Expose, Type } from 'class-transformer';
 import { createdDateFieldName } from '../common/constants/upstream-constants';
+import { IsOptional } from 'class-validator';
 
 /*
  * Examples
@@ -383,9 +384,11 @@ export class AttachmentsEntity {
 export class AttachmentDetailsEntity extends AttachmentsEntity {
   @ApiProperty({
     example: AttachmentDetailsCaseExample['Attachment Id'],
+    required: false,
   })
+  @IsOptional()
   @Expose()
-  'Attachment Id': string;
+  'Attachment Id'?: string;
 }
 
 @Exclude()

--- a/src/entities/contacts.entity.ts
+++ b/src/entities/contacts.entity.ts
@@ -100,7 +100,7 @@ export const ContactsListResponseSRExample = {
  */
 @Exclude()
 @ApiSchema({ name: 'Contact' })
-class ContactsEntity {
+export class ContactsEntity {
   @ApiProperty({
     example: ContactsSingleResponseCaseExample['Id'],
   })

--- a/src/entities/in-person-visits.entity.ts
+++ b/src/entities/in-person-visits.entity.ts
@@ -8,7 +8,7 @@ import {
 /*
  * Examples
  */
-const InPersonVisitsSingleResponseCaseExample = {
+export const InPersonVisitsSingleResponseCaseExample = {
   Name: 'Name here',
   'Visit Description': 'description',
   Id: 'Id-here',
@@ -45,7 +45,7 @@ export const PostInPersonVisitResponseExample = {
  */
 @Exclude()
 @ApiSchema({ name: 'InPersonVisit' })
-class InPersonVisitsEntity {
+export class InPersonVisitsEntity {
   @ApiProperty({
     example: InPersonVisitsSingleResponseCaseExample['Name'],
     required: false,

--- a/src/entities/in-person-visits.entity.ts
+++ b/src/entities/in-person-visits.entity.ts
@@ -118,6 +118,10 @@ export class InPersonVisitsEntity {
   })
   @Expose()
   'Updated': string;
+
+  constructor(object) {
+    Object.assign(this, object);
+  }
 }
 
 @Exclude()

--- a/src/entities/support-network.entity.ts
+++ b/src/entities/support-network.entity.ts
@@ -13,7 +13,7 @@ import {
 /*
  * Examples
  */
-const SupportNetworkSingleResponseCaseExample = {
+export const SupportNetworkSingleResponseCaseExample = {
   'Cell Phone Number': '12345678910',
   'Entity Name': EntityType.Case,
   Name: 'Name',
@@ -36,12 +36,12 @@ const SupportNetworkSingleResponseCaseExample = {
   [updatedDateFieldName]: '01/01/1970 00:00:00',
 };
 
-const SupportNetworkSingleResponseSRExample = {
+export const SupportNetworkSingleResponseSRExample = {
   ...SupportNetworkSingleResponseCaseExample,
   'Entity Name': EntityType.SR,
 };
 
-const SupportNetworkSingleResponseIncidentExample = {
+export const SupportNetworkSingleResponseIncidentExample = {
   ...SupportNetworkSingleResponseCaseExample,
   'Entity Name': EntityType.Incident,
 };
@@ -81,7 +81,7 @@ export const SupportNetworkListResponseIncidentExample = {
  */
 @Exclude()
 @ApiSchema({ name: 'SupportNetwork' })
-class SupportNetworkEntity {
+export class SupportNetworkEntity {
   @ApiProperty({
     example: SupportNetworkSingleResponseCaseExample['Cell Phone Number'],
   })

--- a/src/external-api/request-preparer/request-preparer.service.spec.ts
+++ b/src/external-api/request-preparer/request-preparer.service.spec.ts
@@ -73,15 +73,16 @@ describe('RequestPreparerService', () => {
 
   describe('prepareHeadersAndParams tests', () => {
     it.each([
-      ['spec', undefined],
-      ['spec', 'workspace'],
+      ['spec', undefined, true],
+      ['spec', 'workspace', false],
     ])(
       'correctly prepares headers and params with no date or row number parameter',
-      (baseSearchSpec, workspace) => {
+      (baseSearchSpec, workspace, uniformResponse) => {
         const [headers, params] = service.prepareHeadersAndParams(
           baseSearchSpec,
           workspace,
           '',
+          uniformResponse,
         );
         expect(headers).toEqual({
           Accept: CONTENT_TYPE,
@@ -92,7 +93,9 @@ describe('RequestPreparerService', () => {
           ChildLinks: CHILD_LINKS,
           searchspec: baseSearchSpec + ')',
           workspace: workspace,
-          [uniformResponseParamName]: UNIFORM_RESPONSE,
+          [uniformResponseParamName]: uniformResponse
+            ? UNIFORM_RESPONSE
+            : undefined,
         });
       },
     );
@@ -114,6 +117,7 @@ describe('RequestPreparerService', () => {
           baseSearchSpec,
           workspace,
           '',
+          true,
           filterQueryParams,
         );
         expect(headers).toEqual({
@@ -155,6 +159,7 @@ describe('RequestPreparerService', () => {
           baseSearchSpec,
           undefined,
           'Updated',
+          true,
           filterQueryParams,
         );
         expect(headers).toEqual({

--- a/src/external-api/request-preparer/request-preparer.service.ts
+++ b/src/external-api/request-preparer/request-preparer.service.ts
@@ -40,6 +40,7 @@ export class RequestPreparerService {
     baseSearchSpec: string,
     workspace: string | undefined,
     sinceFieldName: string | undefined,
+    uniformResponse: boolean,
     filter?: FilterQueryParams,
   ) {
     let searchSpec = baseSearchSpec;
@@ -64,9 +65,11 @@ export class RequestPreparerService {
       ViewMode: VIEW_MODE,
       ChildLinks: CHILD_LINKS,
       searchspec: searchSpec,
-      [uniformResponseParamName]: UNIFORM_RESPONSE,
     };
-    if (typeof workspace !== 'undefined') {
+    if (uniformResponse === true) {
+      params[uniformResponseParamName] = UNIFORM_RESPONSE;
+    }
+    if (typeof workspace !== 'undefined' && workspace.trim() !== '') {
       params['workspace'] = workspace;
     }
     if (filter !== undefined) {
@@ -132,6 +135,7 @@ export class RequestPreparerService {
         response.headers[recordCountHeaderName],
       );
     }
+    console.log(response.data);
     return response;
   }
 

--- a/src/external-api/request-preparer/request-preparer.service.ts
+++ b/src/external-api/request-preparer/request-preparer.service.ts
@@ -135,7 +135,6 @@ export class RequestPreparerService {
         response.headers[recordCountHeaderName],
       );
     }
-    console.log(response.data);
     return response;
   }
 

--- a/src/helpers/attachments/attachments.service.ts
+++ b/src/helpers/attachments/attachments.service.ts
@@ -15,6 +15,7 @@ import {
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import {
+  attachmentIdFieldName,
   attachmentIdName,
   idName,
   INLINE_ATTACHMENT,
@@ -81,7 +82,7 @@ export class AttachmentsService {
         true,
         filter,
       );
-    if (id[inlineAttachmentParamName] !== false) {
+    if (filter[inlineAttachmentParamName] !== 'false') {
       params[inlineAttachmentParamName] = INLINE_ATTACHMENT;
     }
     params[uniformResponseParamName] = undefined;
@@ -91,8 +92,8 @@ export class AttachmentsService {
       res,
       params,
     );
-    if (id[inlineAttachmentParamName] === false) {
-      delete response.data[`${attachmentIdName}`]; // prevents exposing url in this field when not a download
+    if (filter[inlineAttachmentParamName] === 'false') {
+      delete response.data[attachmentIdFieldName]; // prevents exposing url in this field when not a download
     }
     return new AttachmentDetailsEntity(response.data);
   }

--- a/src/helpers/contacts/contacts.service.spec.ts
+++ b/src/helpers/contacts/contacts.service.spec.ts
@@ -10,13 +10,19 @@ import { UtilitiesService } from '../utilities/utilities.service';
 import { RecordType } from '../../common/constants/enumerations';
 import { AxiosResponse } from 'axios';
 import {
+  contactIdName,
   idName,
   sinceParamName,
 } from '../../common/constants/parameter-constants';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
-import { IdPathParams } from '../../dto/id-path-params.dto';
 import {
+  ContactIdPathParams,
+  IdPathParams,
+} from '../../dto/id-path-params.dto';
+import {
+  ContactsEntity,
   ContactsListResponseCaseExample,
+  ContactsSingleResponseCaseExample,
   NestedContactsEntity,
 } from '../../entities/contacts.entity';
 import { getMockRes } from '@jest-mock/express';
@@ -58,7 +64,7 @@ describe('ContactsService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('getSingleContactRecord tests', () => {
+  describe('getListContactRecord tests', () => {
     it.each([
       [
         ContactsListResponseCaseExample,
@@ -84,7 +90,7 @@ describe('ContactsService', () => {
             statusText: 'OK',
           } as AxiosResponse<any, any>);
 
-        const result = await service.getSingleContactRecord(
+        const result = await service.getListContactRecord(
           recordType,
           idPathParams,
           res,
@@ -92,6 +98,36 @@ describe('ContactsService', () => {
         );
         expect(spy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new NestedContactsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleContactRecord tests', () => {
+    it.each([
+      [
+        ContactsSingleResponseCaseExample,
+        RecordType.Case,
+        { [idName]: 'test', [contactIdName]: 'test2' } as ContactIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, recordType, idPathParams) => {
+        const spy = jest
+          .spyOn(requestPreparerService, 'sendGetRequest')
+          .mockResolvedValueOnce({
+            data: data,
+            headers: {},
+            status: 200,
+            statusText: 'OK',
+          } as AxiosResponse<any, any>);
+
+        const result = await service.getSingleContactRecord(
+          recordType,
+          idPathParams,
+          res,
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(new ContactsEntity(data));
       },
     );
   });

--- a/src/helpers/contacts/contacts.service.ts
+++ b/src/helpers/contacts/contacts.service.ts
@@ -12,7 +12,7 @@ import {
   ContactsEntity,
   NestedContactsEntity,
 } from '../../entities/contacts.entity';
-import { contactIdName } from 'src/common/constants/parameter-constants';
+import { contactIdName } from '../../common/constants/parameter-constants';
 
 @Injectable()
 export class ContactsService {

--- a/src/helpers/in-person-visits/in-person-visits.service.spec.ts
+++ b/src/helpers/in-person-visits/in-person-visits.service.spec.ts
@@ -7,17 +7,20 @@ import { TokenRefresherService } from '../../external-api/token-refresher/token-
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { HttpService } from '@nestjs/axios';
 import { AxiosResponse } from 'axios';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import { IdPathParams, VisitIdPathParams } from '../../dto/id-path-params.dto';
 import { RecordType, VisitDetails } from '../../common/constants/enumerations';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import {
+  InPersonVisitsEntity,
   InPersonVisitsListResponseCaseExample,
+  InPersonVisitsSingleResponseCaseExample,
   NestedInPersonVisitsEntity,
   PostInPersonVisitResponseExample,
 } from '../../entities/in-person-visits.entity';
 import {
   idName,
   sinceParamName,
+  visitIdName,
 } from '../../common/constants/parameter-constants';
 import { PostInPersonVisitDtoUpstream } from '../../dto/post-in-person-visit.dto';
 import { getMockRes } from '@jest-mock/express';
@@ -59,7 +62,7 @@ describe('InPersonVisitsService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('getSingleInPersonVisitRecord tests', () => {
+  describe('getListInPersonVisitRecord tests', () => {
     it.each([
       [
         InPersonVisitsListResponseCaseExample,
@@ -85,7 +88,7 @@ describe('InPersonVisitsService', () => {
             statusText: 'OK',
           } as AxiosResponse<any, any>);
 
-        const result = await service.getSingleInPersonVisitRecord(
+        const result = await service.getListInPersonVisitRecord(
           recordType,
           idPathParams,
           res,
@@ -93,6 +96,36 @@ describe('InPersonVisitsService', () => {
         );
         expect(spy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new NestedInPersonVisitsEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleInPersonVisitRecord tests', () => {
+    it.each([
+      [
+        InPersonVisitsSingleResponseCaseExample,
+        RecordType.Case,
+        { [idName]: 'test', [visitIdName]: 'test2' } as VisitIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, recordType, idPathParams) => {
+        const spy = jest
+          .spyOn(requestPreparerService, 'sendGetRequest')
+          .mockResolvedValueOnce({
+            data: data,
+            headers: {},
+            status: 200,
+            statusText: 'OK',
+          } as AxiosResponse<any, any>);
+
+        const result = await service.getSingleInPersonVisitRecord(
+          recordType,
+          idPathParams,
+          res,
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(new InPersonVisitsEntity(data));
       },
     );
   });

--- a/src/helpers/in-person-visits/in-person-visits.service.ts
+++ b/src/helpers/in-person-visits/in-person-visits.service.ts
@@ -1,15 +1,19 @@
 import { Injectable } from '@nestjs/common';
 import { RecordType } from '../../common/constants/enumerations';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import { IdPathParams, VisitIdPathParams } from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { ConfigService } from '@nestjs/config';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
-import { NestedInPersonVisitsEntity } from '../../entities/in-person-visits.entity';
+import {
+  InPersonVisitsEntity,
+  NestedInPersonVisitsEntity,
+} from '../../entities/in-person-visits.entity';
 import {
   CONTENT_TYPE,
   idName,
   UNIFORM_RESPONSE,
   uniformResponseParamName,
+  visitIdName,
 } from '../../common/constants/parameter-constants';
 import { PostInPersonVisitDtoUpstream } from '../../dto/post-in-person-visit.dto';
 import { Response } from 'express';
@@ -44,6 +48,28 @@ export class InPersonVisitsService {
 
   async getSingleInPersonVisitRecord(
     _type: RecordType,
+    id: VisitIdPathParams,
+    res: Response,
+  ): Promise<InPersonVisitsEntity> {
+    const baseSearchSpec = `([Parent Id]="${id[idName]}" AND [Id]="${id[visitIdName]}"`;
+    const [headers, params] =
+      this.requestPreparerService.prepareHeadersAndParams(
+        baseSearchSpec,
+        this.workspace,
+        this.sinceFieldName,
+        false,
+      );
+    const response = await this.requestPreparerService.sendGetRequest(
+      this.url,
+      headers,
+      res,
+      params,
+    );
+    return new InPersonVisitsEntity(response.data);
+  }
+
+  async getListInPersonVisitRecord(
+    _type: RecordType,
     id: IdPathParams,
     res: Response,
     filter?: FilterQueryParams,
@@ -54,6 +80,7 @@ export class InPersonVisitsService {
         baseSearchSpec,
         this.workspace,
         this.sinceFieldName,
+        true,
         filter,
       );
     const response = await this.requestPreparerService.sendGetRequest(

--- a/src/helpers/support-network/support-network.service.spec.ts
+++ b/src/helpers/support-network/support-network.service.spec.ts
@@ -8,16 +8,22 @@ import { RecordType } from '../../common/constants/enumerations';
 import { SupportNetworkService } from './support-network.service';
 import {
   NestedSupportNetworkEntity,
+  SupportNetworkEntity,
   SupportNetworkListResponseIncidentExample,
   SupportNetworkListResponseSRExample,
+  SupportNetworkSingleResponseIncidentExample,
 } from '../../entities/support-network.entity';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  IdPathParams,
+  SupportNetworkIdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import {
   idName,
   sinceParamName,
+  supportNetworkIdName,
 } from '../../common/constants/parameter-constants';
 import { getMockRes } from '@jest-mock/express';
 import configuration from '../../configuration/configuration';
@@ -58,7 +64,7 @@ describe('SupportNetworkService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('getSingleSupportNetworkInformationRecord tests', () => {
+  describe('getListSupportNetworkInformationRecord tests', () => {
     it.each([
       [
         SupportNetworkListResponseIncidentExample,
@@ -84,7 +90,7 @@ describe('SupportNetworkService', () => {
             statusText: 'OK',
           } as AxiosResponse<any, any>);
 
-        const result = await service.getSingleSupportNetworkInformationRecord(
+        const result = await service.getListSupportNetworkInformationRecord(
           recordType,
           idPathParams,
           res,
@@ -92,6 +98,39 @@ describe('SupportNetworkService', () => {
         );
         expect(spy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new NestedSupportNetworkEntity(data));
+      },
+    );
+  });
+
+  describe('getSingleSupportNetworkInformationRecord tests', () => {
+    it.each([
+      [
+        SupportNetworkSingleResponseIncidentExample,
+        RecordType.Incident,
+        {
+          [idName]: 'test',
+          [supportNetworkIdName]: 'test2',
+        } as SupportNetworkIdPathParams,
+      ],
+    ])(
+      'should return single values given good input',
+      async (data, recordType, idPathParams) => {
+        const spy = jest
+          .spyOn(requestPreparerService, 'sendGetRequest')
+          .mockResolvedValueOnce({
+            data: data,
+            headers: {},
+            status: 200,
+            statusText: 'OK',
+          } as AxiosResponse<any, any>);
+
+        const result = await service.getSingleSupportNetworkInformationRecord(
+          recordType,
+          idPathParams,
+          res,
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(new SupportNetworkEntity(data));
       },
     );
   });

--- a/src/helpers/support-network/support-network.service.ts
+++ b/src/helpers/support-network/support-network.service.ts
@@ -8,7 +8,10 @@ import {
   NestedSupportNetworkEntity,
   SupportNetworkEntity,
 } from '../../entities/support-network.entity';
-import { SupportNetworkIdPathParams } from '../../dto/id-path-params.dto';
+import {
+  IdPathParams,
+  SupportNetworkIdPathParams,
+} from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import {
@@ -40,18 +43,39 @@ export class SupportNetworkService {
     type: RecordType,
     id: SupportNetworkIdPathParams,
     res: Response,
-    filter?: FilterQueryParams,
   ) {
-    let baseSearchSpec = `([Entity Id]="${id[idName]}" AND [Entity Name]="${RecordEntityMap[type]}"`;
-    if (id[supportNetworkIdName] !== undefined) {
-      baseSearchSpec =
-        baseSearchSpec + ` AND [Id]="${id[supportNetworkIdName]}"`;
-    }
+    const baseSearchSpec =
+      `([Entity Id]="${id[idName]}" AND [Entity Name]="${RecordEntityMap[type]}"` +
+      ` AND [Id]="${id[supportNetworkIdName]}"`;
     const [headers, params] =
       this.requestPreparerService.prepareHeadersAndParams(
         baseSearchSpec,
         this.workspace,
         this.sinceFieldName,
+        false,
+      );
+    const response = await this.requestPreparerService.sendGetRequest(
+      this.url,
+      headers,
+      res,
+      params,
+    );
+    return new SupportNetworkEntity(response.data);
+  }
+
+  async getListSupportNetworkInformationRecord(
+    type: RecordType,
+    id: IdPathParams,
+    res: Response,
+    filter?: FilterQueryParams,
+  ) {
+    const baseSearchSpec = `([Entity Id]="${id[idName]}" AND [Entity Name]="${RecordEntityMap[type]}"`;
+    const [headers, params] =
+      this.requestPreparerService.prepareHeadersAndParams(
+        baseSearchSpec,
+        this.workspace,
+        this.sinceFieldName,
+        true,
         filter,
       );
     const response = await this.requestPreparerService.sendGetRequest(
@@ -60,9 +84,6 @@ export class SupportNetworkService {
       res,
       params,
     );
-    if (id[supportNetworkIdName] !== undefined) {
-      return new SupportNetworkEntity(response.data.items[0]);
-    }
     return new NestedSupportNetworkEntity(response.data);
   }
 }

--- a/src/helpers/support-network/support-network.service.ts
+++ b/src/helpers/support-network/support-network.service.ts
@@ -4,11 +4,17 @@ import {
   RecordEntityMap,
   RecordType,
 } from '../../common/constants/enumerations';
-import { NestedSupportNetworkEntity } from '../../entities/support-network.entity';
-import { IdPathParams } from '../../dto/id-path-params.dto';
+import {
+  NestedSupportNetworkEntity,
+  SupportNetworkEntity,
+} from '../../entities/support-network.entity';
+import { SupportNetworkIdPathParams } from '../../dto/id-path-params.dto';
 import { FilterQueryParams } from '../../dto/filter-query-params.dto';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
-import { idName } from '../../common/constants/parameter-constants';
+import {
+  idName,
+  supportNetworkIdName,
+} from '../../common/constants/parameter-constants';
 import { Response } from 'express';
 
 @Injectable()
@@ -32,11 +38,15 @@ export class SupportNetworkService {
 
   async getSingleSupportNetworkInformationRecord(
     type: RecordType,
-    id: IdPathParams,
+    id: SupportNetworkIdPathParams,
     res: Response,
     filter?: FilterQueryParams,
   ) {
-    const baseSearchSpec = `([Entity Id]="${id[idName]}" AND [Entity Name]="${RecordEntityMap[type]}"`;
+    let baseSearchSpec = `([Entity Id]="${id[idName]}" AND [Entity Name]="${RecordEntityMap[type]}"`;
+    if (id[supportNetworkIdName] !== undefined) {
+      baseSearchSpec =
+        baseSearchSpec + ` AND [Id]="${id[supportNetworkIdName]}"`;
+    }
     const [headers, params] =
       this.requestPreparerService.prepareHeadersAndParams(
         baseSearchSpec,
@@ -50,6 +60,9 @@ export class SupportNetworkService {
       res,
       params,
     );
+    if (id[supportNetworkIdName] !== undefined) {
+      return new SupportNetworkEntity(response.data.items[0]);
+    }
     return new NestedSupportNetworkEntity(response.data);
   }
 }


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=73b946ccfbea12504e3aff907befdc9b&sysparm_stack=%24vtb_close_dialog.do&sysparm_time=1736202831371&sysparm_view=)

This PR adds single fetch for all GET endpoints. Note that these don't have query filter parameters like since, as there should always be one and only one result returned, if it exists.

Not also that since there is already an existing single attachment details endpoint for downloads, the non-download endpoint has been implemented using the query parameter 'inlineattachment': 'false'. This endpoint does allow for the use of parameters like since, as it shares the same endpoint with the download endpoint.