### PR TITLE
Feature: Append X-ICM-TrustedUsername

### DIFF
--- a/src/common/constants/upstream-constants.ts
+++ b/src/common/constants/upstream-constants.ts
@@ -17,6 +17,7 @@ const createdDateFieldName = 'Created Date';
 const updatedByFieldName = 'Updated By';
 const updatedByIdFieldName = 'Updated By Id';
 const updatedDateFieldName = 'Updated Date';
+const trustedIdirHeaderName = 'X-ICM-TrustedUsername';
 const pageSizeMin = 1;
 const pageSizeMax = 100;
 const pageSizeDefault = 10;
@@ -45,6 +46,7 @@ export {
   updatedByFieldName,
   updatedByIdFieldName,
   updatedDateFieldName,
+  trustedIdirHeaderName,
   pageSizeMin,
   pageSizeMax,
   pageSizeDefault,

--- a/src/common/guards/auth/auth.service.spec.ts
+++ b/src/common/guards/auth/auth.service.spec.ts
@@ -195,7 +195,11 @@ describe('AuthService', () => {
           statusText: 'OK',
         } as AxiosResponse<any, any>),
       );
-      const result = await service.getAssignedIdirUpstream(id, recordType);
+      const result = await service.getAssignedIdirUpstream(
+        id,
+        recordType,
+        'idir',
+      );
       expect(spy).toHaveBeenCalledTimes(1);
       expect(cacheSpy).toHaveBeenCalledTimes(1);
       expect(result).toEqual(testIdir);
@@ -220,6 +224,7 @@ describe('AuthService', () => {
         const result = await service.getAssignedIdirUpstream(
           validId,
           validRecordType,
+          'idir',
         );
         expect(spy).toHaveBeenCalledTimes(1);
         expect(cacheSpy).toHaveBeenCalledTimes(1);
@@ -249,6 +254,7 @@ describe('AuthService', () => {
         const idir = await service.getAssignedIdirUpstream(
           validId,
           RecordType.Case,
+          'idir',
         );
         expect(spy).toHaveBeenCalledTimes(1);
         expect(cacheSpy).toHaveBeenCalledTimes(1);
@@ -263,6 +269,7 @@ describe('AuthService', () => {
       const result = await service.getAssignedIdirUpstream(
         validId,
         validRecordType,
+        'idir',
       );
       expect(cacheSpy).toHaveBeenCalledTimes(1);
       expect(result).toEqual(null);

--- a/src/common/guards/auth/auth.service.ts
+++ b/src/common/guards/auth/auth.service.ts
@@ -18,7 +18,10 @@ import {
 import { firstValueFrom } from 'rxjs';
 import { AxiosError } from 'axios';
 import { TokenRefresherService } from '../../../external-api/token-refresher/token-refresher.service';
-import { idirUsernameHeaderField } from '../../../common/constants/upstream-constants';
+import {
+  idirUsernameHeaderField,
+  trustedIdirHeaderName,
+} from '../../../common/constants/upstream-constants';
 
 @Injectable()
 export class AuthService {
@@ -59,7 +62,7 @@ export class AuthService {
 
     if (upstreamResult === undefined) {
       this.logger.log(`Cache not hit, going upstream...`);
-      upstreamResult = await this.getAssignedIdirUpstream(id, recordType);
+      upstreamResult = await this.getAssignedIdirUpstream(id, recordType, idir);
       if (upstreamResult !== null) {
         await this.cacheManager.set(key, upstreamResult, this.cacheTime);
       }
@@ -87,6 +90,7 @@ export class AuthService {
   async getAssignedIdirUpstream(
     id: string,
     recordType: RecordType,
+    idir: string,
   ): Promise<string | null> {
     let workspace;
     const params = {
@@ -104,6 +108,7 @@ export class AuthService {
     const headers = {
       Accept: CONTENT_TYPE,
       'Accept-Encoding': '*',
+      [trustedIdirHeaderName]: idir,
     };
     const url =
       this.baseUrl +

--- a/src/controllers/cases/cases.controller.spec.ts
+++ b/src/controllers/cases/cases.controller.spec.ts
@@ -69,6 +69,7 @@ describe('CasesController', () => {
   let controller: CasesController;
   let casesService: CasesService;
   const { res, mockClear } = getMockRes();
+  const req = getMockReq({ headers: { [idirUsernameHeaderField]: 'idir' } });
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -120,6 +121,7 @@ describe('CasesController', () => {
 
         const result =
           await controller.getListCaseSupportNetworkInformationRecord(
+            req,
             idPathParams,
             res,
             filterQueryParams,
@@ -127,6 +129,7 @@ describe('CasesController', () => {
         expect(casesServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedSupportNetworkEntity(data));
@@ -152,10 +155,11 @@ describe('CasesController', () => {
 
         const result =
           await controller.getSingleCaseSupportNetworkInformationRecord(
+            req,
             idPathParams,
             res,
           );
-        expect(casesServiceSpy).toHaveBeenCalledWith(idPathParams, res);
+        expect(casesServiceSpy).toHaveBeenCalledWith(idPathParams, res, 'idir');
         expect(result).toEqual(new SupportNetworkEntity(data));
       },
     );
@@ -181,6 +185,7 @@ describe('CasesController', () => {
           );
 
         const result = await controller.getListCaseInPersonVisitRecord(
+          req,
           idPathParams,
           res,
           filterQueryParams,
@@ -188,6 +193,7 @@ describe('CasesController', () => {
         expect(casesServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedInPersonVisitsEntity(data));
@@ -209,10 +215,11 @@ describe('CasesController', () => {
           .mockReturnValueOnce(Promise.resolve(new InPersonVisitsEntity(data)));
 
         const result = await controller.getSingleCaseInPersonVisitRecord(
+          req,
           idPathParams,
           res,
         );
-        expect(casesServiceSpy).toHaveBeenCalledWith(idPathParams, res);
+        expect(casesServiceSpy).toHaveBeenCalledWith(idPathParams, res, 'idir');
         expect(result).toEqual(new InPersonVisitsEntity(data));
       },
     );
@@ -240,9 +247,9 @@ describe('CasesController', () => {
           );
 
         const result = await controller.postSingleCaseInPersonVisitRecord(
+          getMockReq({ headers: { [idirUsernameHeaderField]: idir } }),
           body,
           idPathParams,
-          getMockReq({ headers: { [idirUsernameHeaderField]: idir } }),
         );
         expect(casesServiceSpy).toHaveBeenCalledWith(body, idir, idPathParams);
         expect(result).toEqual(new NestedInPersonVisitsEntity(data));
@@ -270,6 +277,7 @@ describe('CasesController', () => {
           );
 
         const result = await controller.getSingleCaseAttachmentRecord(
+          req,
           idPathParams,
           res,
           filterQueryParams,
@@ -277,6 +285,7 @@ describe('CasesController', () => {
         expect(caseServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
@@ -319,6 +328,7 @@ describe('CasesController', () => {
           );
 
         const result = await controller.getSingleCaseAttachmentDetailsRecord(
+          req,
           idPathParams,
           res,
           filterQueryParams,
@@ -326,6 +336,7 @@ describe('CasesController', () => {
         expect(caseServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new AttachmentDetailsEntity(data));
@@ -351,6 +362,7 @@ describe('CasesController', () => {
           .mockReturnValueOnce(Promise.resolve(new NestedContactsEntity(data)));
 
         const result = await controller.getListCaseContactRecord(
+          req,
           idPathParams,
           res,
           filterQueryParams,
@@ -358,6 +370,7 @@ describe('CasesController', () => {
         expect(caseServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
@@ -379,10 +392,11 @@ describe('CasesController', () => {
           .mockReturnValueOnce(Promise.resolve(new ContactsEntity(data)));
 
         const result = await controller.getSingleCaseContactRecord(
+          req,
           idPathParams,
           res,
         );
-        expect(caseServiceSpy).toHaveBeenCalledWith(idPathParams, res);
+        expect(caseServiceSpy).toHaveBeenCalledWith(idPathParams, res, 'idir');
         expect(result).toEqual(new ContactsEntity(data));
       },
     );

--- a/src/controllers/cases/cases.controller.ts
+++ b/src/controllers/cases/cases.controller.ts
@@ -133,6 +133,7 @@ export class CasesController {
     },
   })
   async getListCaseSupportNetworkInformationRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -155,6 +156,7 @@ export class CasesController {
     return await this.casesService.getListCaseSupportNetworkInformationRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
       filter,
     );
   }
@@ -181,6 +183,7 @@ export class CasesController {
     },
   })
   async getSingleCaseSupportNetworkInformationRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -194,6 +197,7 @@ export class CasesController {
     return await this.casesService.getSingleCaseSupportNetworkInformationRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
     );
   }
 
@@ -225,6 +229,7 @@ export class CasesController {
     },
   })
   async getListCaseInPersonVisitRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -247,6 +252,7 @@ export class CasesController {
     return await this.casesService.getListCaseInPersonVisitRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
       filter,
     );
   }
@@ -273,6 +279,7 @@ export class CasesController {
     },
   })
   async getSingleCaseInPersonVisitRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -283,7 +290,11 @@ export class CasesController {
     id: VisitIdPathParams,
     @Res({ passthrough: true }) res: Response,
   ): Promise<InPersonVisitsEntity> {
-    return await this.casesService.getSingleCaseInPersonVisitRecord(id, res);
+    return await this.casesService.getSingleCaseInPersonVisitRecord(
+      id,
+      res,
+      req.headers[idirUsernameHeaderField] as string,
+    );
   }
 
   @UseInterceptors(ClassSerializerInterceptor)
@@ -304,6 +315,7 @@ export class CasesController {
     },
   })
   async postSingleCaseInPersonVisitRecord(
+    @Req() req: Request,
     @Body(
       new ValidationPipe({
         transform: true,
@@ -320,7 +332,6 @@ export class CasesController {
       }),
     )
     id: IdPathParams,
-    @Req() req: Request,
   ): Promise<NestedInPersonVisitsEntity> {
     return await this.casesService.postSingleCaseInPersonVisitRecord(
       inPersonVisitDto,
@@ -357,6 +368,7 @@ export class CasesController {
     },
   })
   async getSingleCaseAttachmentRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -379,6 +391,7 @@ export class CasesController {
     return await this.casesService.getSingleCaseAttachmentRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
       filter,
     );
   }
@@ -415,6 +428,7 @@ export class CasesController {
     },
   })
   async getSingleCaseAttachmentDetailsRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -437,6 +451,7 @@ export class CasesController {
     return await this.casesService.getSingleCaseAttachmentDetailsRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
       filter,
     );
   }
@@ -469,6 +484,7 @@ export class CasesController {
     },
   })
   async getListCaseContactRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -488,7 +504,12 @@ export class CasesController {
     )
     filter?: FilterQueryParams,
   ): Promise<NestedContactsEntity> {
-    return await this.casesService.getListCaseContactRecord(id, res, filter);
+    return await this.casesService.getListCaseContactRecord(
+      id,
+      res,
+      req.headers[idirUsernameHeaderField] as string,
+      filter,
+    );
   }
 
   @UseInterceptors(ClassSerializerInterceptor)
@@ -513,6 +534,7 @@ export class CasesController {
     },
   })
   async getSingleCaseContactRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -523,6 +545,10 @@ export class CasesController {
     id: ContactIdPathParams,
     @Res({ passthrough: true }) res: Response,
   ): Promise<ContactsEntity> {
-    return await this.casesService.getSingleCaseContactRecord(id, res);
+    return await this.casesService.getSingleCaseContactRecord(
+      id,
+      res,
+      req.headers[idirUsernameHeaderField] as string,
+    );
   }
 }

--- a/src/controllers/cases/cases.service.spec.ts
+++ b/src/controllers/cases/cases.service.spec.ts
@@ -130,12 +130,14 @@ describe('CasesService', () => {
         const result = await service.getListCaseSupportNetworkInformationRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(supportNetworkSpy).toHaveBeenCalledWith(
           RecordType.Case,
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedSupportNetworkEntity(data));
@@ -166,11 +168,13 @@ describe('CasesService', () => {
           await service.getSingleCaseSupportNetworkInformationRecord(
             idPathParams,
             res,
+            'idir',
           );
         expect(supportNetworkSpy).toHaveBeenCalledWith(
           RecordType.Case,
           idPathParams,
           res,
+          'idir',
         );
         expect(result).toEqual(new SupportNetworkEntity(data));
       },
@@ -199,12 +203,14 @@ describe('CasesService', () => {
         const result = await service.getListCaseInPersonVisitRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(InPersonVisitsSpy).toHaveBeenCalledWith(
           RecordType.Case,
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedInPersonVisitsEntity(data));
@@ -228,11 +234,13 @@ describe('CasesService', () => {
         const result = await service.getSingleCaseInPersonVisitRecord(
           idPathParams,
           res,
+          'idir',
         );
         expect(InPersonVisitsSpy).toHaveBeenCalledWith(
           RecordType.Case,
           idPathParams,
           res,
+          'idir',
         );
         expect(result).toEqual(new InPersonVisitsEntity(data));
       },
@@ -291,6 +299,7 @@ describe('CasesService', () => {
         const result = await service.getSingleCaseAttachmentRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(attachmentsSpy).toHaveBeenCalledWith(
@@ -298,6 +307,7 @@ describe('CasesService', () => {
           idPathParams,
           typeFieldName,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
@@ -340,6 +350,7 @@ describe('CasesService', () => {
         const result = await service.getSingleCaseAttachmentDetailsRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(attachmentsSpy).toHaveBeenCalledWith(
@@ -347,6 +358,7 @@ describe('CasesService', () => {
           idPathParams,
           typeFieldName,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new AttachmentDetailsEntity(data));
@@ -374,12 +386,14 @@ describe('CasesService', () => {
         const result = await service.getListCaseContactRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(contactsSpy).toHaveBeenCalledWith(
           RecordType.Case,
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
@@ -403,11 +417,13 @@ describe('CasesService', () => {
         const result = await service.getSingleCaseContactRecord(
           idPathParams,
           res,
+          'idir',
         );
         expect(contactsSpy).toHaveBeenCalledWith(
           RecordType.Case,
           idPathParams,
           res,
+          'idir',
         );
         expect(result).toEqual(new ContactsEntity(data));
       },

--- a/src/controllers/cases/cases.service.ts
+++ b/src/controllers/cases/cases.service.ts
@@ -57,23 +57,27 @@ export class CasesService {
   async getSingleCaseSupportNetworkInformationRecord(
     id: SupportNetworkIdPathParams,
     res: Response,
+    idir: string,
   ): Promise<SupportNetworkEntity> {
     return await this.supportNetworkService.getSingleSupportNetworkInformationRecord(
       RecordType.Case,
       id,
       res,
+      idir,
     );
   }
 
   async getListCaseSupportNetworkInformationRecord(
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedSupportNetworkEntity> {
     return await this.supportNetworkService.getListSupportNetworkInformationRecord(
       RecordType.Case,
       id,
       res,
+      idir,
       filter,
     );
   }
@@ -81,23 +85,27 @@ export class CasesService {
   async getSingleCaseInPersonVisitRecord(
     id: VisitIdPathParams,
     res: Response,
+    idir: string,
   ): Promise<InPersonVisitsEntity> {
     return await this.inPersonVisitsService.getSingleInPersonVisitRecord(
       RecordType.Case,
       id,
       res,
+      idir,
     );
   }
 
   async getListCaseInPersonVisitRecord(
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedInPersonVisitsEntity> {
     return await this.inPersonVisitsService.getListInPersonVisitRecord(
       RecordType.Case,
       id,
       res,
+      idir,
       filter,
     );
   }
@@ -115,12 +123,14 @@ export class CasesService {
     return await this.inPersonVisitsService.postSingleInPersonVisitRecord(
       RecordType.Case,
       body,
+      idir,
     );
   }
 
   async getSingleCaseAttachmentRecord(
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedAttachmentsEntity> {
     return await this.attachmentsService.getSingleAttachmentRecord(
@@ -128,6 +138,7 @@ export class CasesService {
       id,
       casesAttachmentsFieldName,
       res,
+      idir,
       filter,
     );
   }
@@ -135,6 +146,7 @@ export class CasesService {
   async getSingleCaseAttachmentDetailsRecord(
     id: AttachmentIdPathParams,
     res: Response,
+    idir: string,
     filter?: AttachmentDetailsQueryParams,
   ): Promise<AttachmentDetailsEntity> {
     return await this.attachmentsService.getSingleAttachmentDetailsRecord(
@@ -142,6 +154,7 @@ export class CasesService {
       id,
       casesAttachmentsFieldName,
       res,
+      idir,
       filter,
     );
   }
@@ -149,23 +162,27 @@ export class CasesService {
   async getSingleCaseContactRecord(
     id: ContactIdPathParams,
     res: Response,
+    idir: string,
   ): Promise<ContactsEntity> {
     return await this.contactsService.getSingleContactRecord(
       RecordType.Case,
       id,
       res,
+      idir,
     );
   }
 
   async getListCaseContactRecord(
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedContactsEntity> {
     return await this.contactsService.getListContactRecord(
       RecordType.Case,
       id,
       res,
+      idir,
       filter,
     );
   }

--- a/src/controllers/incidents/incidents.controller.spec.ts
+++ b/src/controllers/incidents/incidents.controller.spec.ts
@@ -41,8 +41,11 @@ import {
   AttachmentsSingleResponseIncidentExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
-import { getMockRes } from '@jest-mock/express';
-import { startRowNumParamName } from '../../common/constants/upstream-constants';
+import { getMockReq, getMockRes } from '@jest-mock/express';
+import {
+  idirUsernameHeaderField,
+  startRowNumParamName,
+} from '../../common/constants/upstream-constants';
 import configuration from '../../configuration/configuration';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
 import {
@@ -56,6 +59,7 @@ describe('IncidentsController', () => {
   let controller: IncidentsController;
   let incidentsService: IncidentsService;
   const { res, mockClear } = getMockRes();
+  const req = getMockReq({ headers: { [idirUsernameHeaderField]: 'idir' } });
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -109,6 +113,7 @@ describe('IncidentsController', () => {
 
         const result =
           await controller.getListIncidentSupportNetworkInformationRecord(
+            req,
             idPathParams,
             res,
             filterQueryParams,
@@ -116,6 +121,7 @@ describe('IncidentsController', () => {
         expect(IncidentsServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedSupportNetworkEntity(data));
@@ -144,10 +150,15 @@ describe('IncidentsController', () => {
 
         const result =
           await controller.getSingleIncidentSupportNetworkInformationRecord(
+            req,
             idPathParams,
             res,
           );
-        expect(IncidentsServiceSpy).toHaveBeenCalledWith(idPathParams, res);
+        expect(IncidentsServiceSpy).toHaveBeenCalledWith(
+          idPathParams,
+          res,
+          'idir',
+        );
         expect(result).toEqual(new SupportNetworkEntity(data));
       },
     );
@@ -173,6 +184,7 @@ describe('IncidentsController', () => {
           );
 
         const result = await controller.getSingleIncidentAttachmentRecord(
+          req,
           idPathParams,
           res,
           filterQueryParams,
@@ -180,6 +192,7 @@ describe('IncidentsController', () => {
         expect(incidentServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
@@ -223,6 +236,7 @@ describe('IncidentsController', () => {
 
         const result =
           await controller.getSingleIncidentAttachmentDetailsRecord(
+            req,
             idPathParams,
             res,
             filterQueryParams,
@@ -230,6 +244,7 @@ describe('IncidentsController', () => {
         expect(incidentServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new AttachmentDetailsEntity(data));
@@ -255,6 +270,7 @@ describe('IncidentsController', () => {
           .mockReturnValueOnce(Promise.resolve(new NestedContactsEntity(data)));
 
         const result = await controller.getListIncidentContactRecord(
+          req,
           idPathParams,
           res,
           filterQueryParams,
@@ -262,6 +278,7 @@ describe('IncidentsController', () => {
         expect(incidentServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
@@ -283,10 +300,15 @@ describe('IncidentsController', () => {
           .mockReturnValueOnce(Promise.resolve(new ContactsEntity(data)));
 
         const result = await controller.getSingleIncidentContactRecord(
+          req,
           idPathParams,
           res,
         );
-        expect(incidentServiceSpy).toHaveBeenCalledWith(idPathParams, res);
+        expect(incidentServiceSpy).toHaveBeenCalledWith(
+          idPathParams,
+          res,
+          'idir',
+        );
         expect(result).toEqual(new ContactsEntity(data));
       },
     );

--- a/src/controllers/incidents/incidents.controller.ts
+++ b/src/controllers/incidents/incidents.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Param,
   Query,
+  Req,
   Res,
   UseGuards,
   UseInterceptors,
@@ -59,13 +60,14 @@ import {
   AttachmentDetailsIncidentExample,
   AttachmentsSingleResponseIncidentExample,
 } from '../../entities/attachments.entity';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import {
   noContentResponseSwagger,
   totalRecordCountHeadersSwagger,
   versionInfo,
 } from '../../common/constants/swagger-constants';
 import {
+  idirUsernameHeaderField,
   pageSizeParamName,
   recordCountNeededParamName,
   startRowNumParamName,
@@ -119,6 +121,7 @@ export class IncidentsController {
     },
   })
   async getListIncidentSupportNetworkInformationRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -141,6 +144,7 @@ export class IncidentsController {
     return await this.incidentsService.getListIncidentSupportNetworkInformationRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
       filter,
     );
   }
@@ -166,6 +170,7 @@ export class IncidentsController {
     },
   })
   async getSingleIncidentSupportNetworkInformationRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -179,6 +184,7 @@ export class IncidentsController {
     return await this.incidentsService.getSingleIncidentSupportNetworkInformationRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
     );
   }
 
@@ -209,6 +215,7 @@ export class IncidentsController {
     },
   })
   async getSingleIncidentAttachmentRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -231,6 +238,7 @@ export class IncidentsController {
     return await this.incidentsService.getSingleIncidentAttachmentRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
       filter,
     );
   }
@@ -266,6 +274,7 @@ export class IncidentsController {
     },
   })
   async getSingleIncidentAttachmentDetailsRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -288,6 +297,7 @@ export class IncidentsController {
     return await this.incidentsService.getSingleIncidentAttachmentDetailsRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
       filter,
     );
   }
@@ -319,6 +329,7 @@ export class IncidentsController {
     },
   })
   async getListIncidentContactRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -341,6 +352,7 @@ export class IncidentsController {
     return await this.incidentsService.getListIncidentContactRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
       filter,
     );
   }
@@ -366,6 +378,7 @@ export class IncidentsController {
     },
   })
   async getSingleIncidentContactRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -376,6 +389,10 @@ export class IncidentsController {
     id: ContactIdPathParams,
     @Res({ passthrough: true }) res: Response,
   ): Promise<ContactsEntity> {
-    return await this.incidentsService.getSingleIncidentContactRecord(id, res);
+    return await this.incidentsService.getSingleIncidentContactRecord(
+      id,
+      res,
+      req.headers[idirUsernameHeaderField] as string,
+    );
   }
 }

--- a/src/controllers/incidents/incidents.service.spec.ts
+++ b/src/controllers/incidents/incidents.service.spec.ts
@@ -119,12 +119,14 @@ describe('IncidentsService', () => {
           await service.getListIncidentSupportNetworkInformationRecord(
             idPathParams,
             res,
+            'idir',
             filterQueryParams,
           );
         expect(supportNetworkSpy).toHaveBeenCalledWith(
           RecordType.Incident,
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedSupportNetworkEntity(data));
@@ -155,11 +157,13 @@ describe('IncidentsService', () => {
           await service.getSingleIncidentSupportNetworkInformationRecord(
             idPathParams,
             res,
+            'idir',
           );
         expect(supportNetworkSpy).toHaveBeenCalledWith(
           RecordType.Incident,
           idPathParams,
           res,
+          'idir',
         );
         expect(result).toEqual(new SupportNetworkEntity(data));
       },
@@ -189,6 +193,7 @@ describe('IncidentsService', () => {
         const result = await service.getSingleIncidentAttachmentRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(attachmentsSpy).toHaveBeenCalledWith(
@@ -196,6 +201,7 @@ describe('IncidentsService', () => {
           idPathParams,
           typeFieldName,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
@@ -238,6 +244,7 @@ describe('IncidentsService', () => {
         const result = await service.getSingleIncidentAttachmentDetailsRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(attachmentsSpy).toHaveBeenCalledWith(
@@ -245,6 +252,7 @@ describe('IncidentsService', () => {
           idPathParams,
           typeFieldName,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new AttachmentDetailsEntity(data));
@@ -272,12 +280,14 @@ describe('IncidentsService', () => {
         const result = await service.getListIncidentContactRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(contactsSpy).toHaveBeenCalledWith(
           RecordType.Incident,
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
@@ -301,11 +311,13 @@ describe('IncidentsService', () => {
         const result = await service.getSingleIncidentContactRecord(
           idPathParams,
           res,
+          'idir',
         );
         expect(contactsSpy).toHaveBeenCalledWith(
           RecordType.Incident,
           idPathParams,
           res,
+          'idir',
         );
         expect(result).toEqual(new ContactsEntity(data));
       },

--- a/src/controllers/incidents/incidents.service.ts
+++ b/src/controllers/incidents/incidents.service.ts
@@ -39,23 +39,27 @@ export class IncidentsService {
   async getSingleIncidentSupportNetworkInformationRecord(
     id: SupportNetworkIdPathParams,
     res: Response,
+    idir: string,
   ): Promise<SupportNetworkEntity> {
     return await this.supportNetworkService.getSingleSupportNetworkInformationRecord(
       RecordType.Incident,
       id,
       res,
+      idir,
     );
   }
 
   async getListIncidentSupportNetworkInformationRecord(
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedSupportNetworkEntity> {
     return await this.supportNetworkService.getListSupportNetworkInformationRecord(
       RecordType.Incident,
       id,
       res,
+      idir,
       filter,
     );
   }
@@ -63,6 +67,7 @@ export class IncidentsService {
   async getSingleIncidentAttachmentRecord(
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedAttachmentsEntity> {
     return await this.attachmentsService.getSingleAttachmentRecord(
@@ -70,6 +75,7 @@ export class IncidentsService {
       id,
       incidentsAttachmentsFieldName,
       res,
+      idir,
       filter,
     );
   }
@@ -77,6 +83,7 @@ export class IncidentsService {
   async getSingleIncidentAttachmentDetailsRecord(
     id: AttachmentIdPathParams,
     res: Response,
+    idir: string,
     filter?: AttachmentDetailsQueryParams,
   ): Promise<AttachmentDetailsEntity> {
     return await this.attachmentsService.getSingleAttachmentDetailsRecord(
@@ -84,6 +91,7 @@ export class IncidentsService {
       id,
       incidentsAttachmentsFieldName,
       res,
+      idir,
       filter,
     );
   }
@@ -91,23 +99,27 @@ export class IncidentsService {
   async getSingleIncidentContactRecord(
     id: ContactIdPathParams,
     res: Response,
+    idir: string,
   ): Promise<ContactsEntity> {
     return await this.contactsService.getSingleContactRecord(
       RecordType.Incident,
       id,
       res,
+      idir,
     );
   }
 
   async getListIncidentContactRecord(
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedContactsEntity> {
     return await this.contactsService.getListContactRecord(
       RecordType.Incident,
       id,
       res,
+      idir,
       filter,
     );
   }

--- a/src/controllers/memos/memos.controller.spec.ts
+++ b/src/controllers/memos/memos.controller.spec.ts
@@ -31,8 +31,11 @@ import {
   AttachmentsSingleResponseMemoExample,
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
-import { getMockRes } from '@jest-mock/express';
-import { startRowNumParamName } from '../../common/constants/upstream-constants';
+import { getMockReq, getMockRes } from '@jest-mock/express';
+import {
+  idirUsernameHeaderField,
+  startRowNumParamName,
+} from '../../common/constants/upstream-constants';
 import configuration from '../../configuration/configuration';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
 import {
@@ -45,6 +48,7 @@ describe('MemosController', () => {
   let controller: MemosController;
   let memosService: MemosService;
   const { res, mockClear } = getMockRes();
+  const req = getMockReq({ headers: { [idirUsernameHeaderField]: 'idir' } });
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -92,6 +96,7 @@ describe('MemosController', () => {
           );
 
         const result = await controller.getSingleMemoAttachmentRecord(
+          req,
           idPathParams,
           res,
           filterQueryParams,
@@ -99,6 +104,7 @@ describe('MemosController', () => {
         expect(memoServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
@@ -141,6 +147,7 @@ describe('MemosController', () => {
           );
 
         const result = await controller.getSingleMemoAttachmentDetailsRecord(
+          req,
           idPathParams,
           res,
           filterQueryParams,
@@ -148,6 +155,7 @@ describe('MemosController', () => {
         expect(memoServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new AttachmentDetailsEntity(data));
@@ -173,6 +181,7 @@ describe('MemosController', () => {
           .mockReturnValueOnce(Promise.resolve(new NestedContactsEntity(data)));
 
         const result = await controller.getListMemoContactRecord(
+          req,
           idPathParams,
           res,
           filterQueryParams,
@@ -180,6 +189,7 @@ describe('MemosController', () => {
         expect(memoServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
@@ -201,10 +211,11 @@ describe('MemosController', () => {
           .mockReturnValueOnce(Promise.resolve(new ContactsEntity(data)));
 
         const result = await controller.getSingleMemoContactRecord(
+          req,
           idPathParams,
           res,
         );
-        expect(memoServiceSpy).toHaveBeenCalledWith(idPathParams, res);
+        expect(memoServiceSpy).toHaveBeenCalledWith(idPathParams, res, 'idir');
         expect(result).toEqual(new ContactsEntity(data));
       },
     );

--- a/src/controllers/memos/memos.controller.ts
+++ b/src/controllers/memos/memos.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Param,
   Query,
+  Req,
   Res,
   UseInterceptors,
   ValidationPipe,
@@ -48,13 +49,14 @@ import {
   AttachmentsSingleResponseMemoExample,
 } from '../../entities/attachments.entity';
 import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import {
   noContentResponseSwagger,
   totalRecordCountHeadersSwagger,
   versionInfo,
 } from '../../common/constants/swagger-constants';
 import {
+  idirUsernameHeaderField,
   pageSizeParamName,
   recordCountNeededParamName,
   startRowNumParamName,
@@ -108,6 +110,7 @@ export class MemosController {
     },
   })
   async getSingleMemoAttachmentRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -130,6 +133,7 @@ export class MemosController {
     return await this.memosService.getSingleMemoAttachmentRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
       filter,
     );
   }
@@ -165,6 +169,7 @@ export class MemosController {
     },
   })
   async getSingleMemoAttachmentDetailsRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -187,6 +192,7 @@ export class MemosController {
     return await this.memosService.getSingleMemoAttachmentDetailsRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
       filter,
     );
   }
@@ -218,6 +224,7 @@ export class MemosController {
     },
   })
   async getListMemoContactRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -237,7 +244,12 @@ export class MemosController {
     )
     filter?: FilterQueryParams,
   ): Promise<NestedContactsEntity> {
-    return await this.memosService.getListMemoContactRecord(id, res, filter);
+    return await this.memosService.getListMemoContactRecord(
+      id,
+      res,
+      req.headers[idirUsernameHeaderField] as string,
+      filter,
+    );
   }
 
   @UseInterceptors(ClassSerializerInterceptor)
@@ -261,6 +273,7 @@ export class MemosController {
     },
   })
   async getSingleMemoContactRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -271,6 +284,10 @@ export class MemosController {
     id: ContactIdPathParams,
     @Res({ passthrough: true }) res: Response,
   ): Promise<ContactsEntity> {
-    return await this.memosService.getSingleMemoContactRecord(id, res);
+    return await this.memosService.getSingleMemoContactRecord(
+      id,
+      res,
+      req.headers[idirUsernameHeaderField] as string,
+    );
   }
 }

--- a/src/controllers/memos/memos.service.spec.ts
+++ b/src/controllers/memos/memos.service.spec.ts
@@ -103,6 +103,7 @@ describe('MemosService', () => {
         const result = await service.getSingleMemoAttachmentRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(attachmentsSpy).toHaveBeenCalledWith(
@@ -110,6 +111,7 @@ describe('MemosService', () => {
           idPathParams,
           typeFieldName,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
@@ -152,6 +154,7 @@ describe('MemosService', () => {
         const result = await service.getSingleMemoAttachmentDetailsRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(attachmentsSpy).toHaveBeenCalledWith(
@@ -159,6 +162,7 @@ describe('MemosService', () => {
           idPathParams,
           typeFieldName,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new AttachmentDetailsEntity(data));
@@ -186,12 +190,14 @@ describe('MemosService', () => {
         const result = await service.getListMemoContactRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(contactsSpy).toHaveBeenCalledWith(
           RecordType.Memo,
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
@@ -215,11 +221,13 @@ describe('MemosService', () => {
         const result = await service.getSingleMemoContactRecord(
           idPathParams,
           res,
+          'idir',
         );
         expect(contactsSpy).toHaveBeenCalledWith(
           RecordType.Memo,
           idPathParams,
           res,
+          'idir',
         );
         expect(result).toEqual(new ContactsEntity(data));
       },

--- a/src/controllers/memos/memos.service.ts
+++ b/src/controllers/memos/memos.service.ts
@@ -32,6 +32,7 @@ export class MemosService {
   async getSingleMemoAttachmentRecord(
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedAttachmentsEntity> {
     return await this.attachmentsService.getSingleAttachmentRecord(
@@ -39,6 +40,7 @@ export class MemosService {
       id,
       memoAttachmentsFieldName,
       res,
+      idir,
       filter,
     );
   }
@@ -46,6 +48,7 @@ export class MemosService {
   async getSingleMemoAttachmentDetailsRecord(
     id: AttachmentIdPathParams,
     res: Response,
+    idir: string,
     filter?: AttachmentDetailsQueryParams,
   ): Promise<AttachmentDetailsEntity> {
     return await this.attachmentsService.getSingleAttachmentDetailsRecord(
@@ -53,6 +56,7 @@ export class MemosService {
       id,
       memoAttachmentsFieldName,
       res,
+      idir,
       filter,
     );
   }
@@ -60,23 +64,27 @@ export class MemosService {
   async getSingleMemoContactRecord(
     id: ContactIdPathParams,
     res: Response,
+    idir: string,
   ): Promise<ContactsEntity> {
     return await this.contactsService.getSingleContactRecord(
       RecordType.Memo,
       id,
       res,
+      idir,
     );
   }
 
   async getListMemoContactRecord(
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedContactsEntity> {
     return await this.contactsService.getListContactRecord(
       RecordType.Memo,
       id,
       res,
+      idir,
       filter,
     );
   }

--- a/src/controllers/service-requests/service-requests.controller.spec.ts
+++ b/src/controllers/service-requests/service-requests.controller.spec.ts
@@ -41,8 +41,11 @@ import {
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import { AuthService } from '../../common/guards/auth/auth.service';
-import { getMockRes } from '@jest-mock/express';
-import { startRowNumParamName } from '../../common/constants/upstream-constants';
+import { getMockReq, getMockRes } from '@jest-mock/express';
+import {
+  idirUsernameHeaderField,
+  startRowNumParamName,
+} from '../../common/constants/upstream-constants';
 import configuration from '../../configuration/configuration';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
 import {
@@ -56,6 +59,7 @@ describe('ServiceRequestsController', () => {
   let controller: ServiceRequestsController;
   let serviceRequestsService: ServiceRequestsService;
   const { res, mockClear } = getMockRes();
+  const req = getMockReq({ headers: { [idirUsernameHeaderField]: 'idir' } });
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -113,6 +117,7 @@ describe('ServiceRequestsController', () => {
 
         const result =
           await controller.getListSRSupportNetworkInformationRecord(
+            req,
             idPathParams,
             res,
             filterQueryParams,
@@ -120,6 +125,7 @@ describe('ServiceRequestsController', () => {
         expect(SRsServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedSupportNetworkEntity(data));
@@ -148,10 +154,11 @@ describe('ServiceRequestsController', () => {
 
         const result =
           await controller.getSingleSRSupportNetworkInformationRecord(
+            req,
             idPathParams,
             res,
           );
-        expect(SRsServiceSpy).toHaveBeenCalledWith(idPathParams, res);
+        expect(SRsServiceSpy).toHaveBeenCalledWith(idPathParams, res, 'idir');
         expect(result).toEqual(new SupportNetworkEntity(data));
       },
     );
@@ -177,6 +184,7 @@ describe('ServiceRequestsController', () => {
           );
 
         const result = await controller.getSingleSRAttachmentRecord(
+          req,
           idPathParams,
           res,
           filterQueryParams,
@@ -184,6 +192,7 @@ describe('ServiceRequestsController', () => {
         expect(SRsServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
@@ -226,6 +235,7 @@ describe('ServiceRequestsController', () => {
           );
 
         const result = await controller.getSingleSRAttachmentDetailsRecord(
+          req,
           idPathParams,
           res,
           filterQueryParams,
@@ -233,6 +243,7 @@ describe('ServiceRequestsController', () => {
         expect(SRsServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new AttachmentDetailsEntity(data));
@@ -258,6 +269,7 @@ describe('ServiceRequestsController', () => {
           .mockReturnValueOnce(Promise.resolve(new NestedContactsEntity(data)));
 
         const result = await controller.getListSRContactRecord(
+          req,
           idPathParams,
           res,
           filterQueryParams,
@@ -265,6 +277,7 @@ describe('ServiceRequestsController', () => {
         expect(SRsServiceSpy).toHaveBeenCalledWith(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
@@ -290,10 +303,11 @@ describe('ServiceRequestsController', () => {
           .mockReturnValueOnce(Promise.resolve(new ContactsEntity(data)));
 
         const result = await controller.getSingleSRContactRecord(
+          req,
           idPathParams,
           res,
         );
-        expect(SRsServiceSpy).toHaveBeenCalledWith(idPathParams, res);
+        expect(SRsServiceSpy).toHaveBeenCalledWith(idPathParams, res, 'idir');
         expect(result).toEqual(new ContactsEntity(data));
       },
     );

--- a/src/controllers/service-requests/service-requests.controller.ts
+++ b/src/controllers/service-requests/service-requests.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Param,
   Query,
+  Req,
   Res,
   UseGuards,
   UseInterceptors,
@@ -58,13 +59,14 @@ import {
   NestedAttachmentsEntity,
 } from '../../entities/attachments.entity';
 import { AuthGuard } from '../../common/guards/auth/auth.guard';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import {
   noContentResponseSwagger,
   totalRecordCountHeadersSwagger,
   versionInfo,
 } from '../../common/constants/swagger-constants';
 import {
+  idirUsernameHeaderField,
   pageSizeParamName,
   recordCountNeededParamName,
   startRowNumParamName,
@@ -118,6 +120,7 @@ export class ServiceRequestsController {
     },
   })
   async getListSRSupportNetworkInformationRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -140,6 +143,7 @@ export class ServiceRequestsController {
     return await this.serviceRequestService.getListSRSupportNetworkInformationRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
       filter,
     );
   }
@@ -165,6 +169,7 @@ export class ServiceRequestsController {
     },
   })
   async getSingleSRSupportNetworkInformationRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -178,6 +183,7 @@ export class ServiceRequestsController {
     return await this.serviceRequestService.getSingleSRSupportNetworkInformationRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
     );
   }
 
@@ -208,6 +214,7 @@ export class ServiceRequestsController {
     },
   })
   async getSingleSRAttachmentRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -230,6 +237,7 @@ export class ServiceRequestsController {
     return await this.serviceRequestService.getSingleSRAttachmentRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
       filter,
     );
   }
@@ -265,6 +273,7 @@ export class ServiceRequestsController {
     },
   })
   async getSingleSRAttachmentDetailsRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -287,6 +296,7 @@ export class ServiceRequestsController {
     return await this.serviceRequestService.getSingleSRAttachmentDetailsRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
       filter,
     );
   }
@@ -318,6 +328,7 @@ export class ServiceRequestsController {
     },
   })
   async getListSRContactRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -340,6 +351,7 @@ export class ServiceRequestsController {
     return await this.serviceRequestService.getListSRContactRecord(
       id,
       res,
+      req.headers[idirUsernameHeaderField] as string,
       filter,
     );
   }
@@ -365,6 +377,7 @@ export class ServiceRequestsController {
     },
   })
   async getSingleSRContactRecord(
+    @Req() req: Request,
     @Param(
       new ValidationPipe({
         transform: true,
@@ -375,6 +388,10 @@ export class ServiceRequestsController {
     id: ContactIdPathParams,
     @Res({ passthrough: true }) res: Response,
   ): Promise<ContactsEntity> {
-    return await this.serviceRequestService.getSingleSRContactRecord(id, res);
+    return await this.serviceRequestService.getSingleSRContactRecord(
+      id,
+      res,
+      req.headers[idirUsernameHeaderField] as string,
+    );
   }
 }

--- a/src/controllers/service-requests/service-requests.service.spec.ts
+++ b/src/controllers/service-requests/service-requests.service.spec.ts
@@ -119,12 +119,14 @@ describe('ServiceRequestsService', () => {
         const result = await service.getListSRSupportNetworkInformationRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(supportNetworkSpy).toHaveBeenCalledWith(
           RecordType.SR,
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedSupportNetworkEntity(data));
@@ -154,11 +156,13 @@ describe('ServiceRequestsService', () => {
         const result = await service.getSingleSRSupportNetworkInformationRecord(
           idPathParams,
           res,
+          'idir',
         );
         expect(supportNetworkSpy).toHaveBeenCalledWith(
           RecordType.SR,
           idPathParams,
           res,
+          'idir',
         );
         expect(result).toEqual(new SupportNetworkEntity(data));
       },
@@ -188,6 +192,7 @@ describe('ServiceRequestsService', () => {
         const result = await service.getSingleSRAttachmentRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(attachmentsSpy).toHaveBeenCalledWith(
@@ -195,6 +200,7 @@ describe('ServiceRequestsService', () => {
           idPathParams,
           typeFieldName,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedAttachmentsEntity(data));
@@ -237,6 +243,7 @@ describe('ServiceRequestsService', () => {
         const result = await service.getSingleSRAttachmentDetailsRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(attachmentsSpy).toHaveBeenCalledWith(
@@ -244,6 +251,7 @@ describe('ServiceRequestsService', () => {
           idPathParams,
           typeFieldName,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new AttachmentDetailsEntity(data));
@@ -271,12 +279,14 @@ describe('ServiceRequestsService', () => {
         const result = await service.getListSRContactRecord(
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(contactsSpy).toHaveBeenCalledWith(
           RecordType.SR,
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(result).toEqual(new NestedContactsEntity(data));
@@ -300,11 +310,13 @@ describe('ServiceRequestsService', () => {
         const result = await service.getSingleSRContactRecord(
           idPathParams,
           res,
+          'idir',
         );
         expect(contactsSpy).toHaveBeenCalledWith(
           RecordType.SR,
           idPathParams,
           res,
+          'idir',
         );
         expect(result).toEqual(new ContactsEntity(data));
       },

--- a/src/controllers/service-requests/service-requests.service.ts
+++ b/src/controllers/service-requests/service-requests.service.ts
@@ -39,23 +39,27 @@ export class ServiceRequestsService {
   async getSingleSRSupportNetworkInformationRecord(
     id: SupportNetworkIdPathParams,
     res: Response,
+    idir: string,
   ): Promise<SupportNetworkEntity> {
     return await this.supportNetworkService.getSingleSupportNetworkInformationRecord(
       RecordType.SR,
       id,
       res,
+      idir,
     );
   }
 
   async getListSRSupportNetworkInformationRecord(
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedSupportNetworkEntity> {
     return await this.supportNetworkService.getListSupportNetworkInformationRecord(
       RecordType.SR,
       id,
       res,
+      idir,
       filter,
     );
   }
@@ -63,6 +67,7 @@ export class ServiceRequestsService {
   async getSingleSRAttachmentRecord(
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedAttachmentsEntity> {
     return await this.attachmentsService.getSingleAttachmentRecord(
@@ -70,6 +75,7 @@ export class ServiceRequestsService {
       id,
       srAttachmentsFieldName,
       res,
+      idir,
       filter,
     );
   }
@@ -77,6 +83,7 @@ export class ServiceRequestsService {
   async getSingleSRAttachmentDetailsRecord(
     id: AttachmentIdPathParams,
     res: Response,
+    idir: string,
     filter?: AttachmentDetailsQueryParams,
   ): Promise<AttachmentDetailsEntity> {
     return await this.attachmentsService.getSingleAttachmentDetailsRecord(
@@ -84,6 +91,7 @@ export class ServiceRequestsService {
       id,
       srAttachmentsFieldName,
       res,
+      idir,
       filter,
     );
   }
@@ -91,23 +99,27 @@ export class ServiceRequestsService {
   async getSingleSRContactRecord(
     id: ContactIdPathParams,
     res: Response,
+    idir: string,
   ): Promise<ContactsEntity> {
     return await this.contactsService.getSingleContactRecord(
       RecordType.SR,
       id,
       res,
+      idir,
     );
   }
 
   async getListSRContactRecord(
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedContactsEntity> {
     return await this.contactsService.getListContactRecord(
       RecordType.SR,
       id,
       res,
+      idir,
       filter,
     );
   }

--- a/src/external-api/request-preparer/request-preparer.service.spec.ts
+++ b/src/external-api/request-preparer/request-preparer.service.spec.ts
@@ -27,6 +27,7 @@ import {
   pageSizeParamName,
   recordCountNeededParamName,
   startRowNumParamName,
+  trustedIdirHeaderName,
 } from '../../common/constants/upstream-constants';
 import { RecordCountNeededEnum } from '../../common/constants/enumerations';
 import configuration from '../../configuration/configuration';
@@ -83,10 +84,12 @@ describe('RequestPreparerService', () => {
           workspace,
           '',
           uniformResponse,
+          'idir',
         );
         expect(headers).toEqual({
           Accept: CONTENT_TYPE,
           'Accept-Encoding': '*',
+          [trustedIdirHeaderName]: 'idir',
         });
         expect(params).toEqual({
           ViewMode: VIEW_MODE,
@@ -118,11 +121,13 @@ describe('RequestPreparerService', () => {
           workspace,
           '',
           true,
+          'idir',
           filterQueryParams,
         );
         expect(headers).toEqual({
           Accept: CONTENT_TYPE,
           'Accept-Encoding': '*',
+          [trustedIdirHeaderName]: 'idir',
         });
         expect(params).toEqual({
           ViewMode: VIEW_MODE,
@@ -160,11 +165,13 @@ describe('RequestPreparerService', () => {
           undefined,
           'Updated',
           true,
+          'idir',
           filterQueryParams,
         );
         expect(headers).toEqual({
           Accept: CONTENT_TYPE,
           'Accept-Encoding': '*',
+          [trustedIdirHeaderName]: 'idir',
         });
         expect(params).toEqual({
           ViewMode: VIEW_MODE,

--- a/src/external-api/request-preparer/request-preparer.service.ts
+++ b/src/external-api/request-preparer/request-preparer.service.ts
@@ -20,6 +20,7 @@ import {
   pageSizeParamName,
   recordCountNeededParamName,
   startRowNumParamName,
+  trustedIdirHeaderName,
 } from '../../common/constants/upstream-constants';
 import { RecordCountNeededEnum } from '../../common/constants/enumerations';
 
@@ -41,6 +42,7 @@ export class RequestPreparerService {
     workspace: string | undefined,
     sinceFieldName: string | undefined,
     uniformResponse: boolean,
+    idir: string,
     filter?: FilterQueryParams,
   ) {
     let searchSpec = baseSearchSpec;
@@ -86,6 +88,7 @@ export class RequestPreparerService {
     const headers = {
       Accept: CONTENT_TYPE,
       'Accept-Encoding': '*',
+      [trustedIdirHeaderName]: idir,
     };
     return [headers, params];
   }

--- a/src/helpers/attachments/attachments.service.spec.ts
+++ b/src/helpers/attachments/attachments.service.spec.ts
@@ -84,6 +84,7 @@ describe('AttachmentsService', () => {
           id,
           typeFieldName,
           res,
+          'idir',
           filter,
         );
         expect(spy).toHaveBeenCalledTimes(1);
@@ -117,6 +118,7 @@ describe('AttachmentsService', () => {
           id,
           typeFieldName,
           res,
+          'idir',
           filter,
         );
         expect(spy).toHaveBeenCalledTimes(1);

--- a/src/helpers/attachments/attachments.service.ts
+++ b/src/helpers/attachments/attachments.service.ts
@@ -46,6 +46,7 @@ export class AttachmentsService {
     id: IdPathParams,
     typeFieldName: string,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedAttachmentsEntity> {
     const baseSearchSpec = `([${typeFieldName}]="${id[idName]}"`;
@@ -55,6 +56,7 @@ export class AttachmentsService {
         this.workspace,
         this.sinceFieldName,
         true,
+        idir,
         filter,
       );
     const response = await this.requestPreparerService.sendGetRequest(
@@ -71,6 +73,7 @@ export class AttachmentsService {
     id: AttachmentIdPathParams,
     typeFieldName: string,
     res: Response,
+    idir: string,
     filter?: AttachmentDetailsQueryParams,
   ): Promise<AttachmentDetailsEntity> {
     const baseSearchSpec = `([${typeFieldName}]="${id[idName]}"`;
@@ -80,6 +83,7 @@ export class AttachmentsService {
         this.workspace,
         this.sinceFieldName,
         true,
+        idir,
         filter,
       );
     if (filter[inlineAttachmentParamName] !== 'false') {

--- a/src/helpers/contacts/contacts.service.spec.ts
+++ b/src/helpers/contacts/contacts.service.spec.ts
@@ -94,6 +94,7 @@ describe('ContactsService', () => {
           recordType,
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(spy).toHaveBeenCalledTimes(1);
@@ -125,6 +126,7 @@ describe('ContactsService', () => {
           recordType,
           idPathParams,
           res,
+          'idir',
         );
         expect(spy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new ContactsEntity(data));

--- a/src/helpers/contacts/contacts.service.ts
+++ b/src/helpers/contacts/contacts.service.ts
@@ -49,6 +49,7 @@ export class ContactsService {
     type: RecordType,
     id: ContactIdPathParams,
     res: Response,
+    idir: string,
   ): Promise<ContactsEntity> {
     const baseSearchSpec = `([Id]="${id[contactIdName]}"`;
     const upstreamUrl = this.constructUpstreamUrl(type, id);
@@ -58,6 +59,7 @@ export class ContactsService {
         this.workspace,
         this.sinceFieldName,
         false,
+        idir,
       );
     const response = await this.requestPreparerService.sendGetRequest(
       upstreamUrl,
@@ -72,6 +74,7 @@ export class ContactsService {
     type: RecordType,
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedContactsEntity> {
     const baseSearchSpec = ``;
@@ -82,6 +85,7 @@ export class ContactsService {
         this.workspace,
         this.sinceFieldName,
         true,
+        idir,
         filter,
       );
     const response = await this.requestPreparerService.sendGetRequest(

--- a/src/helpers/in-person-visits/in-person-visits.service.spec.ts
+++ b/src/helpers/in-person-visits/in-person-visits.service.spec.ts
@@ -92,6 +92,7 @@ describe('InPersonVisitsService', () => {
           recordType,
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(spy).toHaveBeenCalledTimes(1);
@@ -123,6 +124,7 @@ describe('InPersonVisitsService', () => {
           recordType,
           idPathParams,
           res,
+          'idir',
         );
         expect(spy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new InPersonVisitsEntity(data));
@@ -156,6 +158,7 @@ describe('InPersonVisitsService', () => {
         const result = await service.postSingleInPersonVisitRecord(
           recordType,
           body,
+          'idir',
         );
         expect(spy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new NestedInPersonVisitsEntity(data));

--- a/src/helpers/in-person-visits/in-person-visits.service.ts
+++ b/src/helpers/in-person-visits/in-person-visits.service.ts
@@ -17,6 +17,7 @@ import {
 } from '../../common/constants/parameter-constants';
 import { PostInPersonVisitDtoUpstream } from '../../dto/post-in-person-visit.dto';
 import { Response } from 'express';
+import { trustedIdirHeaderName } from '../../common/constants/upstream-constants';
 
 @Injectable()
 export class InPersonVisitsService {
@@ -50,6 +51,7 @@ export class InPersonVisitsService {
     _type: RecordType,
     id: VisitIdPathParams,
     res: Response,
+    idir: string,
   ): Promise<InPersonVisitsEntity> {
     const baseSearchSpec = `([Parent Id]="${id[idName]}" AND [Id]="${id[visitIdName]}"`;
     const [headers, params] =
@@ -58,6 +60,7 @@ export class InPersonVisitsService {
         this.workspace,
         this.sinceFieldName,
         false,
+        idir,
       );
     const response = await this.requestPreparerService.sendGetRequest(
       this.url,
@@ -72,6 +75,7 @@ export class InPersonVisitsService {
     _type: RecordType,
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ): Promise<NestedInPersonVisitsEntity> {
     const baseSearchSpec = `([Parent Id]="${id[idName]}"`;
@@ -81,6 +85,7 @@ export class InPersonVisitsService {
         this.workspace,
         this.sinceFieldName,
         true,
+        idir,
         filter,
       );
     const response = await this.requestPreparerService.sendGetRequest(
@@ -95,11 +100,13 @@ export class InPersonVisitsService {
   async postSingleInPersonVisitRecord(
     _type: RecordType,
     body: PostInPersonVisitDtoUpstream,
+    idir: string,
   ): Promise<NestedInPersonVisitsEntity> {
     const headers = {
       Accept: CONTENT_TYPE,
       'Content-Type': CONTENT_TYPE,
       'Accept-Encoding': '*',
+      [trustedIdirHeaderName]: idir,
     };
     const params = {
       [uniformResponseParamName]: UNIFORM_RESPONSE,

--- a/src/helpers/support-network/support-network.service.spec.ts
+++ b/src/helpers/support-network/support-network.service.spec.ts
@@ -94,6 +94,7 @@ describe('SupportNetworkService', () => {
           recordType,
           idPathParams,
           res,
+          'idir',
           filterQueryParams,
         );
         expect(spy).toHaveBeenCalledTimes(1);
@@ -128,6 +129,7 @@ describe('SupportNetworkService', () => {
           recordType,
           idPathParams,
           res,
+          'idir',
         );
         expect(spy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new SupportNetworkEntity(data));

--- a/src/helpers/support-network/support-network.service.ts
+++ b/src/helpers/support-network/support-network.service.ts
@@ -43,6 +43,7 @@ export class SupportNetworkService {
     type: RecordType,
     id: SupportNetworkIdPathParams,
     res: Response,
+    idir: string,
   ) {
     const baseSearchSpec =
       `([Entity Id]="${id[idName]}" AND [Entity Name]="${RecordEntityMap[type]}"` +
@@ -53,6 +54,7 @@ export class SupportNetworkService {
         this.workspace,
         this.sinceFieldName,
         false,
+        idir,
       );
     const response = await this.requestPreparerService.sendGetRequest(
       this.url,
@@ -67,6 +69,7 @@ export class SupportNetworkService {
     type: RecordType,
     id: IdPathParams,
     res: Response,
+    idir: string,
     filter?: FilterQueryParams,
   ) {
     const baseSearchSpec = `([Entity Id]="${id[idName]}" AND [Entity Name]="${RecordEntityMap[type]}"`;
@@ -76,6 +79,7 @@ export class SupportNetworkService {
         this.workspace,
         this.sinceFieldName,
         true,
+        idir,
         filter,
       );
     const response = await this.requestPreparerService.sendGetRequest(


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=dcaccbd2fb879a144e3aff907befdc51&sysparm_view=&sysparm_time=1736980900260)

This PR adds the "X-ICM-TrustedUsername" header to every upstream request to Siebel, and updates unit tests.