### PR TITLE
Add created date for upstream

### DIFF
--- a/src/common/constants/upstream-constants.ts
+++ b/src/common/constants/upstream-constants.ts
@@ -5,6 +5,7 @@ const postInPersonVisitsEndpointEnvVarName = 'IN_PERSON_VISITS_POST_ENDPOINT';
 const attachmentsEndpointEnvVarName = 'ATTACHMENTS_ENDPOINT';
 const idirUsernameHeaderField = 'x-idir-username';
 const upstreamDateFormat = 'MM/dd/yyyy HH:mm:ss';
+const dummyCreatedDate = '01/01/1970 00:00:00';
 const caseChildServices = 'Child Services';
 const childVisitType = 'In Person Child Youth';
 const childVisitIdirFieldName = 'Login Name';
@@ -35,6 +36,7 @@ export {
   attachmentsEndpointEnvVarName,
   idirUsernameHeaderField,
   upstreamDateFormat,
+  dummyCreatedDate,
   caseChildServices,
   childVisitType,
   childVisitIdirFieldName,

--- a/src/controllers/cases/cases.service.ts
+++ b/src/controllers/cases/cases.service.ts
@@ -44,6 +44,7 @@ import {
   ContactsEntity,
   NestedContactsEntity,
 } from '../../entities/contacts.entity';
+import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 
 @Injectable()
 export class CasesService {
@@ -52,6 +53,7 @@ export class CasesService {
     private readonly inPersonVisitsService: InPersonVisitsService,
     private readonly attachmentsService: AttachmentsService,
     private readonly contactsService: ContactsService,
+    private readonly utilitiesService: UtilitiesService,
   ) {}
 
   async getSingleCaseSupportNetworkInformationRecord(
@@ -119,6 +121,7 @@ export class CasesService {
       ...inPersonVisitsDto,
       [childVisitIdirFieldName]: idir,
       [childVisitEntityIdFieldName]: id[idName],
+      Created: this.utilitiesService.getCurrentDateTimeUpstream(),
     });
     return await this.inPersonVisitsService.postSingleInPersonVisitRecord(
       RecordType.Case,

--- a/src/controllers/cases/cases.service.ts
+++ b/src/controllers/cases/cases.service.ts
@@ -37,6 +37,7 @@ import {
 import {
   childVisitEntityIdFieldName,
   childVisitIdirFieldName,
+  dummyCreatedDate,
 } from '../../common/constants/upstream-constants';
 import { Response } from 'express';
 import { ContactsService } from '../../helpers/contacts/contacts.service';
@@ -44,7 +45,6 @@ import {
   ContactsEntity,
   NestedContactsEntity,
 } from '../../entities/contacts.entity';
-import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 
 @Injectable()
 export class CasesService {
@@ -53,7 +53,6 @@ export class CasesService {
     private readonly inPersonVisitsService: InPersonVisitsService,
     private readonly attachmentsService: AttachmentsService,
     private readonly contactsService: ContactsService,
-    private readonly utilitiesService: UtilitiesService,
   ) {}
 
   async getSingleCaseSupportNetworkInformationRecord(
@@ -121,7 +120,7 @@ export class CasesService {
       ...inPersonVisitsDto,
       [childVisitIdirFieldName]: idir,
       [childVisitEntityIdFieldName]: id[idName],
-      Created: this.utilitiesService.getCurrentDateTimeUpstream(),
+      Created: dummyCreatedDate,
     });
     return await this.inPersonVisitsService.postSingleInPersonVisitRecord(
       RecordType.Case,

--- a/src/dto/post-in-person-visit.dto.ts
+++ b/src/dto/post-in-person-visit.dto.ts
@@ -66,6 +66,8 @@ export class PostInPersonVisitDtoUpstream {
 
   'Visit Details Value': string;
 
+  'Created': string;
+
   constructor(object) {
     Object.assign(this, object);
   }

--- a/src/helpers/utilities/utilities.service.ts
+++ b/src/helpers/utilities/utilities.service.ts
@@ -33,6 +33,12 @@ export class UtilitiesService {
     return upstreamDate;
   }
 
+  getCurrentDateTimeUpstream(): string {
+    return DateTime.now()
+      .setZone('Canada/Pacific')
+      .toFormat(upstreamDateFormat);
+  }
+
   /**
    * Converts a MM/dd/yyyy HH:mm:ss formatted date to a DateTime object.
    * @param upstreamDate a MM/dd/yyyy HH:mm:ss formatted string. Assumes the date given is provided in UTC

--- a/src/helpers/utilities/utilities.service.ts
+++ b/src/helpers/utilities/utilities.service.ts
@@ -33,12 +33,6 @@ export class UtilitiesService {
     return upstreamDate;
   }
 
-  getCurrentDateTimeUpstream(): string {
-    return DateTime.now()
-      .setZone('Canada/Pacific')
-      .toFormat(upstreamDateFormat);
-  }
-
   /**
    * Converts a MM/dd/yyyy HH:mm:ss formatted date to a DateTime object.
    * @param upstreamDate a MM/dd/yyyy HH:mm:ss formatted string. Assumes the date given is provided in UTC


### PR DESCRIPTION
Add created date for upstream to generate ids properly. This created date will get overridden and may be of from the stored date by a few seconds.