### PR TITLE
Icm active user check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,8 @@ INCIDENT_AFTER_FIELD='after field here'
 INCIDENT_RESTRICTED_FIELD='restricted field here'
 SR_IDIR_FIELD='idir field here'
 MEMO_IDIR_FIELD='idir field here'
+EMPLOYEE_WORKSPACE='workspace here'
+EMPLOYEE_ENDPOINT=/endpoint/path/here
 SKIP_AUTH_GUARD=false
 SKIP_JWT_CACHE=false
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -219,6 +219,16 @@ spec:
                 secretKeyRef:
                     name: visitz-api
                     key: CASE_TYPE_FIELD
+            - name: EMPLOYEE_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                    name: visitz-api
+                    key: EMPLOYEE_ENDPOINT
+            - name: EMPLOYEE_WORKSPACE
+              valueFrom:
+                secretKeyRef:
+                    name: visitz-api
+                    key: EMPLOYEE_WORKSPACE
             - name: VPI_APP_LABEL
               value: {{ .Values.vpiAppBuildLabel.version }}
             - name: VPI_APP_ENV

--- a/src/common/guards/auth/auth.service.ts
+++ b/src/common/guards/auth/auth.service.ts
@@ -258,11 +258,11 @@ export class AuthService {
           cause: error.cause,
           buildNumber: this.buildNumber,
         });
+        await this.cacheManager.set(idir, false, this.cacheTime);
       } else {
         this.logger.error({ error, buildNumber: this.buildNumber });
       }
     }
-    await this.cacheManager.set(idir, false, this.cacheTime);
     return false;
   }
 }

--- a/src/common/guards/auth/auth.service.ts
+++ b/src/common/guards/auth/auth.service.ts
@@ -15,13 +15,13 @@ import {
   uniformResponseParamName,
   VIEW_MODE,
 } from '../../../common/constants/parameter-constants';
-import { firstValueFrom } from 'rxjs';
 import { AxiosError } from 'axios';
 import { TokenRefresherService } from '../../../external-api/token-refresher/token-refresher.service';
 import {
   idirUsernameHeaderField,
   trustedIdirHeaderName,
 } from '../../../common/constants/upstream-constants';
+import { firstValueFrom } from 'rxjs';
 
 @Injectable()
 export class AuthService {
@@ -29,6 +29,8 @@ export class AuthService {
   cacheTime: number;
   baseUrl: string;
   buildNumber: string;
+  employeeWorkspace: string;
+  employeeEndpoint: string;
   private readonly logger = new Logger(AuthService.name);
 
   constructor(
@@ -44,6 +46,12 @@ export class AuthService {
     );
     this.buildNumber = this.configService.get<string>('buildInfo.buildNumber');
     this.skipJWT = this.configService.get<boolean>('skipJWTCache');
+    this.employeeWorkspace = this.configService.get<string>(
+      'upstreamAuth.employee.workspace',
+    );
+    this.employeeEndpoint = this.configService.get<string>(
+      'upstreamAuth.employee.endpoint',
+    );
   }
 
   async getRecordAndValidate(
@@ -67,26 +75,46 @@ export class AuthService {
     );
     let upstreamResult: number | null | undefined =
       await this.cacheManager.get(key);
+    let employeeActive: boolean | undefined = await this.cacheManager.get(idir);
 
-    if (upstreamResult === undefined) {
-      this.logger.log(`Cache not hit, going upstream...`);
+    if (upstreamResult === undefined && employeeActive === undefined) {
+      this.logger.log(
+        `Cache not hit for record type and active status, going upstream...`,
+      );
+      let upstreamIdir: string | null;
+      [upstreamIdir, employeeActive] = await Promise.all([
+        this.getAssignedIdirUpstream(id, recordType, idir),
+        this.getEmployeeActiveUpstream(idir),
+      ]);
+      upstreamResult = await this.evaluateUpstreamResult(
+        upstreamIdir,
+        idir,
+        key,
+      );
+    } else if (upstreamResult === undefined) {
+      this.logger.log(`Cache not hit for record type, going upstream...`);
       const upstreamIdir = await this.getAssignedIdirUpstream(
         id,
         recordType,
         idir,
       );
-      const authStatus = upstreamIdir === idir ? 200 : 403;
-      if (upstreamIdir !== null) {
-        await this.cacheManager.set(key, authStatus, this.cacheTime);
-      }
-      upstreamResult = authStatus;
-      this.logger.log(
-        `Upstream idir: '${upstreamIdir}' Result: ${upstreamResult}`,
+      upstreamResult = await this.evaluateUpstreamResult(
+        upstreamIdir,
+        idir,
+        key,
       );
+    } else if (employeeActive === undefined) {
+      this.logger.log(`Cache not hit for active status, going upstream...`);
+      employeeActive = await this.getEmployeeActiveUpstream(idir);
     } else {
-      this.logger.log(`Cache hit! Key: ${key} Result: ${upstreamResult}`);
+      this.logger.log(
+        `Cache hit for record type! Key: ${key} Result: ${upstreamResult}`,
+      );
+      this.logger.log(
+        `Cache hit for employee status! Key: ${idir} Result: ${employeeActive}`,
+      );
     }
-    if (upstreamResult === 403) {
+    if (upstreamResult === 403 || employeeActive == false) {
       return false;
     }
     return true;
@@ -101,6 +129,22 @@ export class AuthService {
       throw new Error(`Id not found in path`);
     }
     return [rowId, controllerPath as RecordType];
+  }
+
+  async evaluateUpstreamResult(
+    upstreamIdir: string | null,
+    idir: string,
+    key: string,
+  ) {
+    const authStatus = upstreamIdir === idir ? 200 : 403;
+    if (upstreamIdir !== null) {
+      await this.cacheManager.set(key, authStatus, this.cacheTime);
+    }
+    const upstreamResult = authStatus;
+    this.logger.log(
+      `Upstream idir: '${upstreamIdir}' Result: ${upstreamResult}`,
+    );
+    return upstreamResult;
   }
 
   async getAssignedIdirUpstream(
@@ -165,5 +209,60 @@ export class AuthService {
       }
     }
     return null;
+  }
+
+  async getEmployeeActiveUpstream(idir: string): Promise<boolean> {
+    const params = {
+      ViewMode: VIEW_MODE,
+      ChildLinks: CHILD_LINKS,
+      [uniformResponseParamName]: UNIFORM_RESPONSE,
+      fields: 'Login Name,Employment Status',
+      excludeEmptyFieldsInResponse: 'true',
+      searchspec: `([Login Name]="${idir}" AND [Employment Status]="Active")`,
+    };
+    if (this.employeeWorkspace !== undefined) {
+      params['workspace'] = this.employeeWorkspace;
+    }
+    const headers = {
+      Accept: CONTENT_TYPE,
+      'Accept-Encoding': '*',
+      [trustedIdirHeaderName]: idir,
+    };
+    const url = this.baseUrl + this.employeeEndpoint;
+
+    let response;
+    try {
+      const token =
+        await this.tokenRefresherService.refreshUpstreamBearerToken();
+      if (token === undefined) {
+        throw new Error('Upstream auth failed');
+      }
+      headers['Authorization'] = token;
+      response = await firstValueFrom(
+        this.httpService.get(url, { params, headers }),
+      );
+      const employmentStatus = response.data['items'][0]['Employment Status'];
+      if (employmentStatus === undefined) {
+        this.logger.error(`${idir} is not an active user`);
+        await this.cacheManager.set(idir, false, this.cacheTime);
+        return false;
+      }
+      await this.cacheManager.set(idir, true, this.cacheTime);
+      return true;
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        this.logger.error({
+          msg: error.message,
+          errorDetails: error.response?.data,
+          stack: error.stack,
+          cause: error.cause,
+          buildNumber: this.buildNumber,
+        });
+      } else {
+        this.logger.error({ error, buildNumber: this.buildNumber });
+      }
+    }
+    await this.cacheManager.set(idir, false, this.cacheTime);
+    return false;
   }
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -31,6 +31,10 @@ export default () => ({
       workspace: process.env.MEMO_WORKSPACE ?? undefined,
       idirField: process.env.MEMO_IDIR_FIELD ?? undefined,
     },
+    employee: {
+      endpoint: encodeURI((process.env.EMPLOYEE_ENDPOINT ?? ' ').trim()),
+      workspace: process.env.EMPLOYEE_WORKSPACE ?? undefined,
+    },
   },
   oauth: {
     accessTokenUrl: process.env.ACCESS_TOKEN_URL ?? ' ',

--- a/src/controllers/controllers.module.ts
+++ b/src/controllers/controllers.module.ts
@@ -4,6 +4,7 @@ import { IncidentsModule } from './incidents/incidents.module';
 import { ServiceRequestsModule } from './service-requests/service-requests.module';
 import { MemosModule } from './memos/memos.module';
 import { CaseloadModule } from './caseload/caseload.module';
+import { ExternalAuthModule } from './external-auth/external-auth.module';
 
 @Module({
   imports: [
@@ -12,6 +13,7 @@ import { CaseloadModule } from './caseload/caseload.module';
     ServiceRequestsModule,
     MemosModule,
     CaseloadModule,
+    ExternalAuthModule,
   ],
 })
 export class ControllersModule {}

--- a/src/controllers/external-auth/external-auth.controller.spec.ts
+++ b/src/controllers/external-auth/external-auth.controller.spec.ts
@@ -1,0 +1,63 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExternalAuthController } from './external-auth.controller';
+import { HttpService } from '@nestjs/axios';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { AuthService } from '../../common/guards/auth/auth.service';
+import configuration from '../../configuration/configuration';
+import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
+import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
+import { UtilitiesService } from '../../helpers/utilities/utilities.service';
+import { ExternalAuthService } from './external-auth.service';
+import { getMockReq } from '@jest-mock/express';
+import { idirUsernameHeaderField } from '../../common/constants/upstream-constants';
+
+describe('ExternalAuthController', () => {
+  let controller: ExternalAuthController;
+  let externalAuthService: ExternalAuthService;
+  const testIdir = 'idir';
+  const req = getMockReq({ headers: { [idirUsernameHeaderField]: testIdir } });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ load: [configuration] }),
+        JwtModule.register({ global: true }),
+      ],
+      providers: [
+        AuthService,
+        ExternalAuthService,
+        TokenRefresherService,
+        RequestPreparerService,
+        JwtService,
+        { provide: CACHE_MANAGER, useValue: {} },
+        ConfigService,
+        UtilitiesService,
+        { provide: HttpService, useValue: { get: jest.fn() } },
+      ],
+      controllers: [ExternalAuthController],
+    }).compile();
+
+    controller = module.get<ExternalAuthController>(ExternalAuthController);
+    externalAuthService = module.get<ExternalAuthService>(ExternalAuthService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('checkAuthorizationEmployeeStatus tests', () => {
+    it.each([[testIdir]])(
+      'should return void given good input',
+      async (idir) => {
+        const externalAuthServiceSpy = jest
+          .spyOn(externalAuthService, 'checkEmployeeStatusUpstream')
+          .mockReturnValueOnce(Promise.resolve());
+
+        await controller.checkAuthorizationEmployeeStatus(req);
+        expect(externalAuthServiceSpy).toHaveBeenCalledWith(idir);
+      },
+    );
+  });
+});

--- a/src/controllers/external-auth/external-auth.controller.ts
+++ b/src/controllers/external-auth/external-auth.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Req } from '@nestjs/common';
+import {
+  ApiParam,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiOperation,
+} from '@nestjs/swagger';
+import { versionInfo } from '../../common/constants/swagger-constants';
+import { ApiForbiddenErrorEntity } from '../../entities/api-forbidden-error.entity';
+import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
+import { ApiUnauthorizedErrorEntity } from '../../entities/api-unauthorized-error.entity';
+import { idirUsernameHeaderField } from '../../common/constants/upstream-constants';
+import { ExternalAuthService } from './external-auth.service';
+import { Request } from 'express';
+
+@Controller('check-authorization')
+@ApiParam(versionInfo)
+@ApiUnauthorizedResponse({ type: ApiUnauthorizedErrorEntity })
+@ApiForbiddenResponse({ type: ApiForbiddenErrorEntity })
+@ApiInternalServerErrorResponse({ type: ApiInternalServerErrorEntity })
+export class ExternalAuthController {
+  constructor(private readonly externalAuthService: ExternalAuthService) {}
+
+  @Get('/')
+  @ApiOperation({
+    description:
+      `Gives the employment status of the employee making the request and caches it. ` +
+      `If return status is 200, employee is active. If return status is 403, employee is not active or not found.`,
+  })
+  @ApiOkResponse({
+    description: 'Empty body. Employee is active.',
+  })
+  async checkAuthorizationEmployeeStatus(@Req() req: Request): Promise<void> {
+    return await this.externalAuthService.checkEmployeeStatusUpstream(
+      req.headers[idirUsernameHeaderField] as string,
+    );
+  }
+}

--- a/src/controllers/external-auth/external-auth.module.ts
+++ b/src/controllers/external-auth/external-auth.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { ExternalAuthController } from './external-auth.controller';
+import { ExternalAuthService } from './external-auth.service';
+import { HttpModule } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { AuthModule } from '../../common/guards/auth/auth.module';
+import { AuthService } from '../../common/guards/auth/auth.service';
+import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
+import { HelpersModule } from '../../helpers/helpers.module';
+import { UtilitiesService } from '../../helpers/utilities/utilities.service';
+
+@Module({
+  providers: [
+    ExternalAuthService,
+    AuthService,
+    ConfigService,
+    UtilitiesService,
+    TokenRefresherService,
+  ],
+  imports: [HelpersModule, AuthModule, HttpModule],
+  controllers: [ExternalAuthController],
+})
+export class ExternalAuthModule {}

--- a/src/controllers/external-auth/external-auth.service.spec.ts
+++ b/src/controllers/external-auth/external-auth.service.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExternalAuthService } from './external-auth.service';
+import { HttpModule } from '@nestjs/axios';
+import { CacheModule } from '@nestjs/cache-manager';
+import { ConfigModule } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import configuration from '../../configuration/configuration';
+import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
+import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
+import { UtilitiesService } from '../../helpers/utilities/utilities.service';
+import { CaseloadService } from '../caseload/caseload.service';
+import { AuthService } from '../../common/guards/auth/auth.service';
+import { HttpException } from '@nestjs/common';
+
+describe('ExternalAuthService', () => {
+  let service: ExternalAuthService;
+  let authService: AuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        HttpModule,
+        ConfigModule.forRoot({ load: [configuration] }),
+        CacheModule.register({ isGlobal: true }),
+      ],
+      providers: [
+        CaseloadService,
+        UtilitiesService,
+        JwtService,
+        TokenRefresherService,
+        RequestPreparerService,
+        ExternalAuthService,
+        AuthService,
+      ],
+    }).compile();
+
+    service = module.get<ExternalAuthService>(ExternalAuthService);
+    authService = module.get<AuthService>(AuthService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('checkEmployeeStatusUpstream tests', () => {
+    it.each([['idirHere']])(
+      'should return void given good input',
+      async (idir) => {
+        const authSpy = jest
+          .spyOn(authService, 'getEmployeeActiveUpstream')
+          .mockReturnValueOnce(Promise.resolve(true));
+        const spy = jest.spyOn(service, 'checkEmployeeStatusUpstream');
+
+        await service.checkEmployeeStatusUpstream(idir);
+        expect(authSpy).toHaveBeenCalledWith(idir);
+        expect(spy).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    it.each([['idirHere']])('should throw error on bad input', async (idir) => {
+      const authSpy = jest
+        .spyOn(authService, 'getEmployeeActiveUpstream')
+        .mockReturnValueOnce(Promise.resolve(false));
+
+      await expect(service.checkEmployeeStatusUpstream(idir)).rejects.toThrow(
+        HttpException,
+      );
+      expect(authSpy).toHaveBeenCalledWith(idir);
+    });
+  });
+});

--- a/src/controllers/external-auth/external-auth.service.ts
+++ b/src/controllers/external-auth/external-auth.service.ts
@@ -1,0 +1,20 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { AuthService } from '../../common/guards/auth/auth.service';
+
+@Injectable()
+export class ExternalAuthService {
+  constructor(private readonly authService: AuthService) {}
+  async checkEmployeeStatusUpstream(idir: string): Promise<void> {
+    const status = await this.authService.getEmployeeActiveUpstream(idir);
+    if (status === false) {
+      throw new HttpException(
+        {
+          status: HttpStatus.FORBIDDEN,
+          error: 'Forbidden',
+          message: 'Forbidden resource',
+        },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+}


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=fc900b5a333f1e1084a805570e5c7b6c&sysparm_view=&sysparm_time=1741206661908)

This PR adds the employment status check to the auth guard. It also adds an endpoint, GET /check-authorization, which returns 200 if the employee accessing it is Active and 403 otherwise, and stores this result in the cache.