### PR TITLE
Feat: Multivalue auth search

### DIFF
--- a/src/common/guards/auth/auth.service.spec.ts
+++ b/src/common/guards/auth/auth.service.spec.ts
@@ -179,24 +179,9 @@ describe('AuthService', () => {
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(true)
         .mockResolvedValueOnce('');
-      const spy = jest.spyOn(httpService, 'get').mockReturnValueOnce(
-        of({
-          data: {
-            items: [
-              {
-                fieldNotAvailable: true,
-              },
-            ],
-          },
-          headers: {},
-          config: {
-            url: 'exampleurl',
-            headers: {} as RawAxiosRequestHeaders,
-          },
-          status: 200,
-          statusText: 'OK',
-        } as AxiosResponse<any, any>),
-      );
+      const spy = jest.spyOn(httpService, 'get').mockImplementationOnce(() => {
+        throw new AxiosError('not found', '404');
+      });
       const mockRequest = getMockReq({
         header: jest.fn((key: string): string => {
           const headerVal: { [key: string]: string } = {
@@ -342,39 +327,12 @@ describe('AuthService', () => {
       const result = await service.getAssignedIdirUpstream(
         id,
         recordType,
-        'idir',
+        testIdir,
       );
       expect(spy).toHaveBeenCalledTimes(1);
       expect(cacheSpy).toHaveBeenCalledTimes(1);
       expect(result).toEqual(testIdir);
     });
-
-    it.each([[{}], [undefined]])(
-      'should return undefined when idir not in response',
-      async (data) => {
-        const cacheSpy = jest.spyOn(cache, 'get').mockResolvedValueOnce(' ');
-        const spy = jest.spyOn(httpService, 'get').mockReturnValueOnce(
-          of({
-            data,
-            headers: {},
-            config: {
-              url: 'exampleurl',
-              headers: {} as RawAxiosRequestHeaders,
-            },
-            status: 200,
-            statusText: 'OK',
-          } as AxiosResponse<any, any>),
-        );
-        const result = await service.getAssignedIdirUpstream(
-          validId,
-          validRecordType,
-          'idir',
-        );
-        expect(spy).toHaveBeenCalledTimes(1);
-        expect(cacheSpy).toHaveBeenCalledTimes(1);
-        expect(result).toEqual(undefined);
-      },
-    );
 
     it.each([[404], [500]])(
       `Should return undefined on axios error`,

--- a/src/common/guards/auth/auth.service.ts
+++ b/src/common/guards/auth/auth.service.ts
@@ -153,10 +153,14 @@ export class AuthService {
     idir: string,
   ): Promise<string | undefined> {
     let workspace;
+    const fieldName = this.configService.get<string>(
+      `upstreamAuth.${recordType}.searchspecIdirField`,
+    );
     const params = {
       ViewMode: VIEW_MODE,
       ChildLinks: CHILD_LINKS,
       [uniformResponseParamName]: UNIFORM_RESPONSE,
+      searchspec: `EXISTS ([${fieldName}]='${idir}')`,
     };
     if (
       (workspace = this.configService.get(
@@ -183,17 +187,10 @@ export class AuthService {
         throw new Error('Upstream auth failed');
       }
       headers['Authorization'] = token;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       response = await firstValueFrom(
         this.httpService.get(url, { params, headers }),
       );
-      const fieldName = this.configService.get<string>(
-        `upstreamAuth.${recordType}.idirField`,
-      );
-      const idir = response.data['items'][0][`${fieldName}`];
-      if (idir === undefined) {
-        this.logger.error(`${fieldName} field not found in request`);
-        return undefined;
-      }
       return idir;
     } catch (error) {
       if (error instanceof AxiosError) {

--- a/src/controllers/caseload/caseload.service.spec.ts
+++ b/src/controllers/caseload/caseload.service.spec.ts
@@ -139,19 +139,19 @@ describe('CaseloadService', () => {
       };
       const caseParams = {
         ...params,
-        searchspec: `([${caseIdirFieldName}]="${idir}")`,
+        searchspec: `EXISTS ([${caseIdirFieldName}]="${idir}")`,
       };
       const incidentParams = {
         ...params,
-        searchspec: `([${incidentIdirFieldName}]="${idir}")`,
+        searchspec: `EXISTS ([${incidentIdirFieldName}]="${idir}")`,
       };
       const srParams = {
         ...params,
-        searchspec: `([${srIdirFieldName}]="${idir}")`,
+        searchspec: `EXISTS ([${srIdirFieldName}]="${idir}")`,
       };
       const memoParams = {
         ...params,
-        searchspec: `([${memoIdirFieldName}]="${idir}")`,
+        searchspec: `EXISTS ([${memoIdirFieldName}]="${idir}")`,
       };
 
       expect(getRequestSpecs.length).toBe(4);

--- a/src/controllers/caseload/caseload.service.ts
+++ b/src/controllers/caseload/caseload.service.ts
@@ -129,7 +129,7 @@ export class CaseloadService {
     const getRequestSpecs: Array<GetRequestDetails> = [];
     for (const type of this.recordTypes) {
       const idirFieldVarName = `${type}IdirFieldName`;
-      const baseSearchSpec = `([${this[idirFieldVarName]}]="${idir}"`;
+      const baseSearchSpec = `EXISTS ([${this[idirFieldVarName]}]="${idir}"`;
       const [headers, params] =
         this.requestPreparerService.prepareHeadersAndParams(
           baseSearchSpec,
@@ -138,6 +138,7 @@ export class CaseloadService {
           true,
           idir,
           filter,
+          true,
         );
       getRequestSpecs.push(
         new GetRequestDetails({

--- a/src/external-api/request-preparer/request-preparer.service.ts
+++ b/src/external-api/request-preparer/request-preparer.service.ts
@@ -53,6 +53,7 @@ export class RequestPreparerService {
     uniformResponse: boolean,
     idir: string,
     filter?: FilterQueryParams,
+    existsQuery?: boolean,
   ) {
     let searchSpec = baseSearchSpec;
     let formattedDate: string | undefined;
@@ -65,6 +66,9 @@ export class RequestPreparerService {
       )) === undefined
     ) {
       searchSpec = searchSpec + `)`;
+    } else if (existsQuery === true) {
+      searchSpec =
+        searchSpec + `) AND ([${afterFieldName}] > "${formattedDate}")`;
     } else {
       searchSpec =
         searchSpec + ` AND [${afterFieldName}] > "${formattedDate}")`;


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/now/nav/ui/classic/params/target/rm_story.do%3Fsys_id%3Df4b2af8dfb3c62504e3aff907befdcdb%26sysparm_view%3D%26sysparm_time%3D1744214533818)

This PR introduces changes to auth guard and caseload auth to allow for multivalue field search for multiple users assigned to the same entity.