### PR TITLE
Add attachments fields

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ INCIDENT_ENDPOINT=/endpoint/path/here
 SR_ENDPOINT=/endpoint/path/here
 MEMO_ENDPOINT=/endpoint/path/here
 ATTACHMENTS_ENDPOINT=/endpoint/path/here
+ATTACHMENTS_AFTER_FIELD='after field here'
 ATTACHMENTS_POST_ENDPOINT=/endpoint/path/here
 CASE_CONTACTS_ENDPOINT=/endpoint/path/here
 INCIDENT_CONTACTS_ENDPOINT=/endpoint/path/here

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -324,6 +324,11 @@ spec:
                 secretKeyRef:
                     name: visitz-api
                     key: CLAMD_BYPASS_TEST
+            - name: ATTACHMENTS_AFTER_FIELD
+              valueFrom:
+                secretKeyRef:
+                    name: visitz-api
+                    key: ATTACHMENTS_AFTER_FIELD
             - name: VPI_APP_LABEL
               value: {{ .Values.vpiAppBuildLabel.version }}
             - name: VPI_APP_ENV

--- a/package-lock.json
+++ b/package-lock.json
@@ -1943,12 +1943,14 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.0.12",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.0.12.tgz",
-      "integrity": "sha512-6PXxmDe2iYmb57xacnxzpW1NAxRZ7Gf+acMT7/hmRB/4KpZiFU/cNvLWwgbM2BL5QSzQulOwY6ny5bbKnPpB+A==",
+      "version": "11.0.20",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.0.20.tgz",
+      "integrity": "sha512-/GH8NDCczjn6+6RNEtSNAts/nq/wQE8L1qZ9TRjqjNqEsZNE1vpFuRIhmcO2isQZ0xY5rySnpaRdrOAul3gQ3A==",
       "license": "MIT",
       "dependencies": {
+        "file-type": "20.4.1",
         "iterare": "1.2.1",
+        "load-esm": "1.0.2",
         "tslib": "2.8.1",
         "uid": "2.0.2"
       },

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -58,7 +58,7 @@ export default () => ({
   afterFieldName: {
     supportNetwork: updatedDateFieldName,
     inPersonVisits: 'Updated',
-    attachments: updatedDateFieldName,
+    attachments: process.env.ATTACHMENTS_AFTER_FIELD ?? updatedDateFieldName,
     contacts: updatedDateFieldName,
     cases: process.env.CASE_AFTER_FIELD ?? undefined,
     incidents: process.env.INCIDENT_AFTER_FIELD ?? undefined,

--- a/src/entities/attachments.entity.ts
+++ b/src/entities/attachments.entity.ts
@@ -53,6 +53,8 @@ export const AttachmentsSingleResponseCaseExample = {
   'Updated By ID': 'Updater Row Id Here',
   [updatedDateFieldName]: '01/01/1970 00:00:00',
   'Last Updated Date': '01/01/1970 00:00:00',
+  CreatedByName: 'Creator Name Here',
+  UpdatedByName: 'Updater Name Here',
 };
 
 export const AttachmentDetailsCaseExample = {
@@ -406,6 +408,18 @@ export class AttachmentsEntity {
   })
   @Expose()
   'Last Updated Date': string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['CreatedByName'],
+  })
+  @Expose()
+  CreatedByName: string;
+
+  @ApiProperty({
+    example: AttachmentsSingleResponseCaseExample['UpdatedByName'],
+  })
+  @Expose()
+  UpdatedByName: string;
 
   constructor(partial: Partial<AttachmentsEntity>) {
     Object.assign(this, partial);


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=9595ca97fb7ca6904e3aff907befdcf6&sysparm_view=&sysparm_time=1744817516891)

This PR contains the following fixes:
- Adds missing attachment fields
- Adds an environment variable to configure the after field for attachments
- Updates @nestjs/common for security reasons