### PR TITLE
Update helm to allow webmethods access to clamav

### DIFF
--- a/clamav/templates/allow-openshift-ingress-network-policy.yaml
+++ b/clamav/templates/allow-openshift-ingress-network-policy.yaml
@@ -12,3 +12,8 @@ spec:
     podSelector:
       matchLabels:
         app.kubernetes.io/name: vpi-app
+  - from:
+    - namespaceSelector: {}
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/name: wm-passthru-app


### PR DESCRIPTION
Title. Must be pushed through to main and ClamAV redeployed for this to take effect.