### PR TITLE
Remove Dependabot Feature Upgrade PRs for NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,5 @@
 version: 2
 updates:
-  # Enable version updates for npm
-  - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
-    directory: "/"
-    # Check the npm registry for updates every day (weekdays)
-    schedule:
-      interval: "daily"
-
   # Enable version updates for Docker
   - package-ecosystem: "docker"
     # Look for a `Dockerfile` in the `root` and `clamav` directory


### PR DESCRIPTION
Change dependabot to stop notifying for non-security related package upgrades, as it will quickly get excessive with the amount of updates NodeJS packages tend to receive.