### PR TITLE
Feat: mTLS authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,3 +74,8 @@ CLAMD_TIMEOUT='scan timeout here'
 CLAMD_CONFIG_FILE='config file location or null here'
 CLAMD_MULTI_SCAN='false'
 CLAMD_BYPASS_TEST='false'
+
+# Certificates
+CA_CERT='ca certificate here'
+SERVER_CERT='server certificate here'
+SERVER_KEY='server key here'

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -349,6 +349,21 @@ spec:
                 secretKeyRef:
                     name: visitz-api
                     key: RESPONSE_NARRATIVES_WORKSPACE
+            - name: CA_CERT
+              valueFrom:
+                secretKeyRef:
+                    name: mutual-authentication-mtls
+                    key: CA_CERT
+            - name: SERVER_CERT
+              valueFrom:
+                secretKeyRef:
+                    name: mutual-authentication-mtls
+                    key: SERVER_CERT
+            - name: SERVER_KEY
+              valueFrom:
+                secretKeyRef:
+                    name: mutual-authentication-mtls
+                    key: SERVER_KEY
             - name: VPI_APP_LABEL
               value: {{ .Values.vpiAppBuildLabel.version }}
             - name: VPI_APP_ENV

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -7,7 +7,7 @@ image:
  
 service:
   type: ClusterIP
-  port: 80
+  port: 443
   containerPort: 3000
  
 resources: {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,13 @@ import { versionNumber } from './common/constants/parameter-constants';
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     bufferLogs: true,
+    httpsOptions: {
+      key: process.env.SERVER_KEY.trim(),
+      cert: [process.env.SERVER_CERT.trim()],
+      ca: process.env.CA_CERT.trim(),
+      requestCert: true,
+      rejectUnauthorized: true,
+    },
   });
   app.useLogger(app.get(Logger));
 


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=7178bdbc93d9e210e09fb1584dba1066&sysparm_view=&sysparm_time=1746554133454)

This PR adds mTLS authentication. Note that this will require end users to have a client certificate to send in order to authenticate.