### PR TITLE
Fix: Character length in free text fields

### DIFF
--- a/src/dto/post-attachment.dto.ts
+++ b/src/dto/post-attachment.dto.ts
@@ -1,11 +1,11 @@
 import { Exclude, Expose, Transform } from 'class-transformer';
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 import {
+  IsByteLength,
   IsEnum,
   IsNotEmpty,
   IsOptional,
   IsString,
-  MaxLength,
 } from 'class-validator';
 import {
   attachmentIdFieldName,
@@ -92,7 +92,7 @@ export class PostAttachmentDto {
 
   @IsNotEmpty()
   @IsString()
-  @MaxLength(attachmentCategoryMax)
+  @IsByteLength(1, attachmentCategoryMax)
   @Transform(({ value }) => {
     return isNotEmoji(value);
   })
@@ -107,7 +107,7 @@ export class PostAttachmentDto {
   @IsOptional()
   @IsNotEmpty()
   @IsString()
-  @MaxLength(attachmentFormDescriptionMax)
+  @IsByteLength(1, attachmentFormDescriptionMax)
   @Transform(({ value }) => {
     return isNotEmoji(value);
   })
@@ -121,7 +121,7 @@ export class PostAttachmentDto {
   'Form Description'?: string;
 
   @IsEnum(AttachmentStatusEnum)
-  @MaxLength(attachmentStatusMax)
+  @IsByteLength(1, attachmentStatusMax)
   @Expose()
   @ApiProperty({
     example: AttachmentStatusEnum.Profiled,
@@ -134,7 +134,7 @@ export class PostAttachmentDto {
   @IsOptional()
   @IsNotEmpty()
   @IsString()
-  @MaxLength(attachmentTemplateMax)
+  @IsByteLength(1, attachmentTemplateMax)
   @Transform(({ value }) => {
     return isNotEmoji(value);
   })

--- a/src/dto/post-in-person-visit.dto.ts
+++ b/src/dto/post-in-person-visit.dto.ts
@@ -4,7 +4,7 @@ import {
   isPastISO8601Date,
 } from '../helpers/utilities/utilities.service';
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
-import { IsEnum, IsNotEmpty, MaxLength } from 'class-validator';
+import { IsByteLength, IsEnum, IsNotEmpty } from 'class-validator';
 import { VisitDetails } from '../common/constants/enumerations';
 import {
   childVisitEntityIdFieldName,
@@ -31,7 +31,7 @@ export class PostInPersonVisitDto {
   'Date of visit': string;
 
   @IsNotEmpty()
-  @MaxLength(visitDescriptionMax)
+  @IsByteLength(1, visitDescriptionMax)
   @Transform(({ value }) => {
     return isNotEmoji(value);
   })
@@ -44,7 +44,7 @@ export class PostInPersonVisitDto {
   'Visit Description': string;
 
   @IsEnum(VisitDetails)
-  @MaxLength(visitDetailsMax)
+  @IsByteLength(1, visitDetailsMax)
   @Expose()
   @ApiProperty({
     example: VisitDetails.PrivateVisitInHome,


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=560584dd2bdd6250f81ff644ce91bffc&sysparm_view=&sysparm_time=1746650059492)

Addresses an issue with visit description not being allowed to submit despite being under the stated character max. Upstream appears to count byte length rather than the number of characters, and subsequently our check has changed to this.