### PR TITLE
Enable multivalue for in person visits

### DIFF
--- a/src/common/constants/parameter-constants.ts
+++ b/src/common/constants/parameter-constants.ts
@@ -8,6 +8,8 @@ const uniformResponseParamName = 'uniformresponse';
 const recordCountHeaderName = 'total-record-count';
 const inlineAttachmentParamName = 'inlineattachment';
 const afterParamName = 'after';
+const queryHierarchyVisitParentClassName = 'ChildVisit';
+const queryHierarchyVisitChildClassName = 'VisitDetails';
 
 const idMaxLength = 100;
 const versionNumber = '2';
@@ -43,6 +45,8 @@ export {
   recordCountHeaderName,
   inlineAttachmentParamName,
   afterParamName,
+  queryHierarchyVisitParentClassName,
+  queryHierarchyVisitChildClassName,
   idMaxLength,
   versionNumber,
   idRegex,

--- a/src/common/constants/upstream-constants.ts
+++ b/src/common/constants/upstream-constants.ts
@@ -4,6 +4,7 @@ const inPersonVisitsEndpointEnvVarName = 'IN_PERSON_VISITS_ENDPOINT';
 const postInPersonVisitsEndpointEnvVarName = 'IN_PERSON_VISITS_POST_ENDPOINT';
 const attachmentsEndpointEnvVarName = 'ATTACHMENTS_ENDPOINT';
 const upstreamAttachmentConstraintNull = 'NULL';
+const upstreamVisitConstraintNull = 'NULL';
 const idirUsernameHeaderField = 'x-idir-username';
 const upstreamDateFormat = 'MM/dd/yyyy HH:mm:ss';
 const dummyCreatedDate = '01/01/1970 00:00:00';
@@ -15,6 +16,8 @@ const startRowNumParamName = 'StartRowNum';
 const recordCountNeededParamName = 'recordcountneeded';
 const pageSizeParamName = 'PageSize';
 const getChildrenParamName = 'getChildren';
+const queryHierarchyParamName = 'QueryHierarchy';
+const multivalueParamName = 'multivalue';
 const createdByFieldName = 'Created By';
 const createdByIdFieldName = 'Created By Id';
 const createdDateFieldName = 'Created Date';
@@ -41,6 +44,7 @@ export {
   postInPersonVisitsEndpointEnvVarName,
   attachmentsEndpointEnvVarName,
   upstreamAttachmentConstraintNull,
+  upstreamVisitConstraintNull,
   idirUsernameHeaderField,
   upstreamDateFormat,
   dummyCreatedDate,
@@ -52,6 +56,8 @@ export {
   recordCountNeededParamName,
   pageSizeParamName,
   getChildrenParamName,
+  queryHierarchyParamName,
+  multivalueParamName,
   createdByFieldName,
   createdByIdFieldName,
   createdDateFieldName,

--- a/src/controllers/cases/cases.controller.spec.ts
+++ b/src/controllers/cases/cases.controller.spec.ts
@@ -29,10 +29,11 @@ import { UtilitiesService } from '../../helpers/utilities/utilities.service';
 import { InPersonVisitsService } from '../../helpers/in-person-visits/in-person-visits.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import {
-  InPersonVisitsEntity,
-  InPersonVisitsListResponseCaseExample,
-  InPersonVisitsSingleResponseCaseExample,
-  NestedInPersonVisitsEntity,
+  InPersonVisitsEntityNoMultiValue,
+  InPersonVisitsListResponseCaseExampleNoMultiValue,
+  InPersonVisitsSingleResponseCaseExampleNoMultiValue,
+  NestedInPersonVisitsMultiValueEntity,
+  NestedInPersonVisitsNoMultiValueEntity,
   PostInPersonVisitResponseExample,
 } from '../../entities/in-person-visits.entity';
 import {
@@ -190,7 +191,7 @@ describe('CasesController', () => {
   describe('getListCaseInPersonVisitRecord tests', () => {
     it.each([
       [
-        InPersonVisitsListResponseCaseExample,
+        InPersonVisitsListResponseCaseExampleNoMultiValue,
         { [idName]: 'test' } as IdPathParams,
         {
           [afterParamName]: '2020-02-02',
@@ -203,7 +204,7 @@ describe('CasesController', () => {
         const casesServiceSpy = jest
           .spyOn(casesService, 'getListCaseInPersonVisitRecord')
           .mockReturnValueOnce(
-            Promise.resolve(new NestedInPersonVisitsEntity(data)),
+            Promise.resolve(new NestedInPersonVisitsNoMultiValueEntity(data)),
           );
 
         const result = await controller.getListCaseInPersonVisitRecord(
@@ -218,7 +219,9 @@ describe('CasesController', () => {
           'idir',
           filterQueryParams,
         );
-        expect(result).toEqual(new NestedInPersonVisitsEntity(data));
+        expect(result).toEqual(
+          new NestedInPersonVisitsNoMultiValueEntity(data),
+        );
       },
     );
   });
@@ -226,7 +229,7 @@ describe('CasesController', () => {
   describe('getSingleCaseInPersonVisitRecord tests', () => {
     it.each([
       [
-        InPersonVisitsSingleResponseCaseExample,
+        InPersonVisitsSingleResponseCaseExampleNoMultiValue,
         { [idName]: 'test', [visitIdName]: 'test2' } as VisitIdPathParams,
       ],
     ])(
@@ -234,15 +237,22 @@ describe('CasesController', () => {
       async (data, idPathParams) => {
         const casesServiceSpy = jest
           .spyOn(casesService, 'getSingleCaseInPersonVisitRecord')
-          .mockReturnValueOnce(Promise.resolve(new InPersonVisitsEntity(data)));
+          .mockReturnValueOnce(
+            Promise.resolve(new InPersonVisitsEntityNoMultiValue(data)),
+          );
 
         const result = await controller.getSingleCaseInPersonVisitRecord(
           req,
           idPathParams,
           res,
         );
-        expect(casesServiceSpy).toHaveBeenCalledWith(idPathParams, res, 'idir');
-        expect(result).toEqual(new InPersonVisitsEntity(data));
+        expect(casesServiceSpy).toHaveBeenCalledWith(
+          idPathParams,
+          res,
+          'idir',
+          undefined,
+        );
+        expect(result).toEqual(new InPersonVisitsEntityNoMultiValue(data));
       },
     );
   });
@@ -265,7 +275,7 @@ describe('CasesController', () => {
         const casesServiceSpy = jest
           .spyOn(casesService, 'postSingleCaseInPersonVisitRecord')
           .mockReturnValueOnce(
-            Promise.resolve(new NestedInPersonVisitsEntity(data)),
+            Promise.resolve(new NestedInPersonVisitsMultiValueEntity(data)),
           );
 
         const result = await controller.postSingleCaseInPersonVisitRecord(
@@ -274,7 +284,7 @@ describe('CasesController', () => {
           idPathParams,
         );
         expect(casesServiceSpy).toHaveBeenCalledWith(body, idir, idPathParams);
-        expect(result).toEqual(new NestedInPersonVisitsEntity(data));
+        expect(result).toEqual(new NestedInPersonVisitsMultiValueEntity(data));
       },
     );
   });

--- a/src/controllers/cases/cases.service.spec.ts
+++ b/src/controllers/cases/cases.service.spec.ts
@@ -32,10 +32,11 @@ import { TokenRefresherService } from '../../external-api/token-refresher/token-
 import { InPersonVisitsService } from '../../helpers/in-person-visits/in-person-visits.service';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import {
-  InPersonVisitsEntity,
+  InPersonVisitsEntityNoMultiValue,
   InPersonVisitsListResponseCaseExample,
-  InPersonVisitsSingleResponseCaseExample,
-  NestedInPersonVisitsEntity,
+  InPersonVisitsSingleResponseCaseExampleNoMultiValue,
+  NestedInPersonVisitsMultiValueEntity,
+  NestedInPersonVisitsNoMultiValueEntity,
   PostInPersonVisitResponseExample,
 } from '../../entities/in-person-visits.entity';
 import {
@@ -219,7 +220,7 @@ describe('CasesService', () => {
         const InPersonVisitsSpy = jest
           .spyOn(inPersonVisitsService, 'getListInPersonVisitRecord')
           .mockReturnValueOnce(
-            Promise.resolve(new NestedInPersonVisitsEntity(data)),
+            Promise.resolve(new NestedInPersonVisitsNoMultiValueEntity(data)),
           );
 
         const result = await service.getListCaseInPersonVisitRecord(
@@ -235,7 +236,9 @@ describe('CasesService', () => {
           'idir',
           filterQueryParams,
         );
-        expect(result).toEqual(new NestedInPersonVisitsEntity(data));
+        expect(result).toEqual(
+          new NestedInPersonVisitsNoMultiValueEntity(data),
+        );
       },
     );
   });
@@ -243,7 +246,7 @@ describe('CasesService', () => {
   describe('getSingleCaseInPersonVisitRecord tests', () => {
     it.each([
       [
-        InPersonVisitsSingleResponseCaseExample,
+        InPersonVisitsSingleResponseCaseExampleNoMultiValue,
         { [idName]: 'test', [visitIdName]: 'test2' } as VisitIdPathParams,
       ],
     ])(
@@ -251,7 +254,9 @@ describe('CasesService', () => {
       async (data, idPathParams) => {
         const InPersonVisitsSpy = jest
           .spyOn(inPersonVisitsService, 'getSingleInPersonVisitRecord')
-          .mockReturnValueOnce(Promise.resolve(new InPersonVisitsEntity(data)));
+          .mockReturnValueOnce(
+            Promise.resolve(new InPersonVisitsEntityNoMultiValue(data)),
+          );
 
         const result = await service.getSingleCaseInPersonVisitRecord(
           idPathParams,
@@ -263,8 +268,9 @@ describe('CasesService', () => {
           idPathParams,
           res,
           'idir',
+          undefined,
         );
-        expect(result).toEqual(new InPersonVisitsEntity(data));
+        expect(result).toEqual(new InPersonVisitsEntityNoMultiValue(data));
       },
     );
   });
@@ -287,7 +293,7 @@ describe('CasesService', () => {
         const InPersonVisitsSpy = jest
           .spyOn(inPersonVisitsService, 'postSingleInPersonVisitRecord')
           .mockReturnValueOnce(
-            Promise.resolve(new NestedInPersonVisitsEntity(data)),
+            Promise.resolve(new NestedInPersonVisitsMultiValueEntity(data)),
           );
 
         const result = await service.postSingleCaseInPersonVisitRecord(
@@ -296,7 +302,7 @@ describe('CasesService', () => {
           idPathParams,
         );
         expect(InPersonVisitsSpy).toHaveBeenCalledTimes(1);
-        expect(result).toEqual(new NestedInPersonVisitsEntity(data));
+        expect(result).toEqual(new NestedInPersonVisitsMultiValueEntity(data));
       },
     );
   });

--- a/src/dto/filter-query-params.dto.ts
+++ b/src/dto/filter-query-params.dto.ts
@@ -104,3 +104,18 @@ export class AttachmentDetailsQueryParams extends FilterQueryParams {
   })
   [inlineAttachmentParamName]?: string = 'true';
 }
+
+@Exclude()
+export class VisitDetailsQueryParams extends FilterQueryParams {
+  @IsOptional()
+  @IsBooleanString()
+  @Expose()
+  @ApiProperty({
+    example: false,
+    default: false,
+    type: 'boolean',
+    description:
+      'Whether or not you want the visit details to be displayed as multiple values.',
+  })
+  multivalue?: string = 'false';
+}

--- a/src/dto/post-in-person-visit.dto.ts
+++ b/src/dto/post-in-person-visit.dto.ts
@@ -1,18 +1,40 @@
-import { Exclude, Expose, Transform } from 'class-transformer';
+import { Exclude, Expose, Transform, Type } from 'class-transformer';
 import {
   isNotEmoji,
   isPastISO8601Date,
 } from '../helpers/utilities/utilities.service';
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
-import { IsEnum, IsNotEmpty, MaxLength } from 'class-validator';
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsEnum,
+  IsNotEmpty,
+  MaxLength,
+  ValidateIf,
+  ValidateNested,
+} from 'class-validator';
 import { VisitDetails } from '../common/constants/enumerations';
 import {
   childVisitEntityIdFieldName,
-  childVisitIdirFieldName,
   childVisitType,
   visitDescriptionMax,
   visitDetailsMax,
 } from '../common/constants/upstream-constants';
+
+@Exclude()
+@ApiSchema({ name: 'PostInPersonVisitDetail' })
+class PostInPersonVisitDetail {
+  @IsEnum(VisitDetails)
+  @MaxLength(visitDetailsMax)
+  @Expose()
+  @ApiProperty({
+    example: VisitDetails.PrivateVisitInHome,
+    description: 'The visit type.',
+    enum: VisitDetails,
+    maxLength: visitDetailsMax,
+  })
+  'Visit Detail Value': string;
+}
 
 @Exclude()
 @ApiSchema({ name: 'PostInPersonVisitRequest' })
@@ -43,26 +65,46 @@ export class PostInPersonVisitDto {
   })
   'Visit Description': string;
 
+  @ValidateIf(
+    (dto) =>
+      typeof dto.VisitDetails === 'undefined' ||
+      (dto.VisitDetails && dto['Visit Details Value']),
+  )
   @IsEnum(VisitDetails)
   @MaxLength(visitDetailsMax)
   @Expose()
   @ApiProperty({
     example: VisitDetails.PrivateVisitInHome,
-    description: 'The visit type',
+    description:
+      'The visit type. Either this field or the VisitDetails array is required. The array takes precedence if both are present.',
     enum: VisitDetails,
     maxLength: visitDetailsMax,
   })
-  'Visit Details Value': string;
-}
+  'Visit Details Value'?: string | undefined;
 
-// TODO: see if Type is a const. If not, add here.
+  @ValidateIf(
+    (dto) =>
+      typeof dto['Visit Details Value'] === 'undefined' ||
+      (dto.VisitDetails && dto['Visit Details Value']),
+  )
+  @ValidateNested()
+  @IsArray()
+  @ArrayNotEmpty()
+  @Expose()
+  @ApiProperty({
+    type: PostInPersonVisitDetail,
+    isArray: true,
+    description:
+      'Either this array or the Visit Details Value field is required. This array takes precedence if both are present.',
+  })
+  @Type(() => PostInPersonVisitDetail)
+  VisitDetails?: Array<PostInPersonVisitDetail> | undefined;
+}
 
 // For use upstream only. Validation not done on parameters here
 // as it should have already been done previously
 export class PostInPersonVisitDtoUpstream {
   'Date of visit': string;
-
-  [childVisitIdirFieldName]: string;
 
   [childVisitEntityIdFieldName]: string;
 
@@ -70,9 +112,17 @@ export class PostInPersonVisitDtoUpstream {
 
   'Visit Description': string;
 
-  'Visit Details Value': string;
+  'VisitDetails': Array<VisitDetail>;
 
-  'Created': string;
+  'Id': string;
+
+  constructor(object) {
+    Object.assign(this, object);
+  }
+}
+
+export class VisitDetail {
+  'Visit Detail Value': string;
 
   constructor(object) {
     Object.assign(this, object);

--- a/src/dto/query-hierarchy-component.dto.ts
+++ b/src/dto/query-hierarchy-component.dto.ts
@@ -1,0 +1,10 @@
+export class QueryHierarchyComponent {
+  classExample: any;
+  name: string;
+  exclude?: Array<string>;
+  searchspec?: string;
+  childComponents?: Array<QueryHierarchyComponent>;
+  constructor(object) {
+    Object.assign(this, object);
+  }
+}

--- a/src/entities/in-person-visits.entity.ts
+++ b/src/entities/in-person-visits.entity.ts
@@ -1,9 +1,12 @@
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
-import { Exclude, Expose, Type } from 'class-transformer';
+import { Exclude, Expose, Transform, Type } from 'class-transformer';
 import {
-  createdByFieldName,
-  updatedByFieldName,
+  createdByIdFieldName,
+  createdDateFieldName,
+  updatedByIdFieldName,
+  updatedDateFieldName,
 } from '../common/constants/upstream-constants';
+import { VisitDetails as VisitDetailsEnum } from '../common/constants/enumerations';
 
 /*
  * Examples
@@ -12,15 +15,35 @@ export const InPersonVisitsSingleResponseCaseExample = {
   Name: 'Name here',
   'Visit Description': 'description',
   Id: 'Id-here',
+  'Row Id': 'Id-here',
   Type: 'In Person Child Youth',
   'Date of visit': '01/01/1970 00:00:00',
-  'Visit Details Value': 'comment',
+  VisitDetails: [
+    {
+      Id: 'Id-1-here',
+      'Visit Detail Value': VisitDetailsEnum.PrivateVisitInHome,
+    },
+    {
+      Id: 'Id-2-here',
+      'Visit Detail Value': VisitDetailsEnum.PrivateVisitZeroToFive,
+    },
+  ],
   'Parent Id': 'Entity-Id-here',
-  'Login Name': 'Idir-here',
-  [createdByFieldName]: 'Creator-Id-Here',
-  Created: '01/01/1970 00:00:00',
-  [updatedByFieldName]: 'Updater-Id-Here',
-  Updated: '01/01/1970 00:00:00',
+  'Created By Name': 'Creator-IDIR-Here',
+  [createdByIdFieldName]: 'Creator-Id-Here',
+  [createdDateFieldName]: '01/01/1970 00:00:00',
+  'Updated By Name': 'Updater-IDIR-Here',
+  [updatedByIdFieldName]: 'Updater-Id-Here',
+  [updatedDateFieldName]: '01/01/1970 00:00:00',
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const { VisitDetails, ...baseCaseBody } =
+  InPersonVisitsSingleResponseCaseExample;
+
+export const InPersonVisitsSingleResponseCaseExampleNoMultiValue = {
+  ...baseCaseBody,
+  'Visit Details Value': VisitDetailsEnum.PrivateVisitInHome,
 };
 
 export const InPersonVisitsListResponseCaseExample = {
@@ -30,6 +53,16 @@ export const InPersonVisitsListResponseCaseExample = {
       'Date of visit': '11/09/2024 10:36:25',
     },
     InPersonVisitsSingleResponseCaseExample,
+  ],
+};
+
+export const InPersonVisitsListResponseCaseExampleNoMultiValue = {
+  items: [
+    {
+      ...InPersonVisitsSingleResponseCaseExampleNoMultiValue,
+      'Date of visit': '11/09/2024 10:36:25',
+    },
+    InPersonVisitsSingleResponseCaseExampleNoMultiValue,
   ],
 };
 
@@ -44,8 +77,31 @@ export const PostInPersonVisitResponseExample = {
  * Model definitions
  */
 @Exclude()
+@ApiSchema({ name: 'InPersonVisitDetailValue' })
+export class VisitDetailValue {
+  @ApiProperty({
+    example: InPersonVisitsSingleResponseCaseExample['VisitDetails'][0]['Id'],
+  })
+  @Expose()
+  Id: string;
+
+  @ApiProperty({
+    example:
+      InPersonVisitsSingleResponseCaseExample['VisitDetails'][0][
+        'Visit Detail Value'
+      ],
+  })
+  @Expose()
+  'Visit Detail Value': string;
+
+  constructor(object) {
+    Object.assign(this, object);
+  }
+}
+
+@Exclude()
 @ApiSchema({ name: 'InPersonVisit' })
-export class InPersonVisitsEntity {
+class InPersonVisitsEntity {
   @ApiProperty({
     example: InPersonVisitsSingleResponseCaseExample['Name'],
     required: false,
@@ -66,6 +122,12 @@ export class InPersonVisitsEntity {
   Id: string;
 
   @ApiProperty({
+    example: InPersonVisitsSingleResponseCaseExample['Row Id'],
+  })
+  @Expose()
+  'Row Id': string;
+
+  @ApiProperty({
     example: InPersonVisitsSingleResponseCaseExample['Type'],
   })
   @Expose()
@@ -78,46 +140,46 @@ export class InPersonVisitsEntity {
   'Date of visit': string;
 
   @ApiProperty({
-    example: InPersonVisitsSingleResponseCaseExample['Visit Details Value'],
-  })
-  @Expose()
-  'Visit Details Value': string;
-
-  @ApiProperty({
     example: InPersonVisitsSingleResponseCaseExample['Parent Id'],
   })
   @Expose()
   'Parent Id': string;
 
   @ApiProperty({
-    example: InPersonVisitsSingleResponseCaseExample['Login Name'],
+    example: InPersonVisitsSingleResponseCaseExample['Created By Name'],
   })
   @Expose()
-  'Login Name': string;
+  'Created By Name': string;
 
   @ApiProperty({
-    example: InPersonVisitsSingleResponseCaseExample[createdByFieldName],
+    example: InPersonVisitsSingleResponseCaseExample[createdByIdFieldName],
   })
   @Expose()
-  [createdByFieldName]: string;
+  [createdByIdFieldName]: string;
 
   @ApiProperty({
-    example: InPersonVisitsSingleResponseCaseExample['Created'],
+    example: InPersonVisitsSingleResponseCaseExample[createdDateFieldName],
   })
   @Expose()
-  'Created': string;
+  [createdDateFieldName]: string;
 
   @ApiProperty({
-    example: InPersonVisitsSingleResponseCaseExample[updatedByFieldName],
+    example: InPersonVisitsSingleResponseCaseExample['Updated By Name'],
   })
   @Expose()
-  [updatedByFieldName]: string;
+  'Updated By Name': string;
 
   @ApiProperty({
-    example: InPersonVisitsSingleResponseCaseExample['Updated'],
+    example: InPersonVisitsSingleResponseCaseExample[updatedByIdFieldName],
   })
   @Expose()
-  'Updated': string;
+  [updatedByIdFieldName]: string;
+
+  @ApiProperty({
+    example: InPersonVisitsSingleResponseCaseExample[updatedDateFieldName],
+  })
+  @Expose()
+  [updatedDateFieldName]: string;
 
   constructor(object) {
     Object.assign(this, object);
@@ -125,12 +187,54 @@ export class InPersonVisitsEntity {
 }
 
 @Exclude()
-@ApiSchema({ name: 'InPersonVisitsResponse' })
-export class NestedInPersonVisitsEntity {
+@ApiSchema({ name: 'InPersonVisitsNoMultiValueResponse' })
+export class InPersonVisitsEntityNoMultiValue extends InPersonVisitsEntity {
+  @ApiProperty({
+    example:
+      InPersonVisitsSingleResponseCaseExampleNoMultiValue[
+        'Visit Details Value'
+      ],
+    name: 'Visit Details Value',
+  })
+  @Type(() => VisitDetailValue)
+  @Transform(({ value }) => value[0]['Visit Detail Value'])
+  @Expose({ name: 'Visit Details Value' })
+  'VisitDetails': string;
+}
+
+@Exclude()
+@ApiSchema({ name: 'InPersonVisitsMultiValueResponse' })
+export class InPersonVisitsEntityMultiValue extends InPersonVisitsEntity {
   @Expose()
-  @ApiProperty({ type: InPersonVisitsEntity, isArray: true })
-  @Type(() => InPersonVisitsEntity)
-  items: Array<InPersonVisitsEntity>;
+  @ApiProperty({
+    example: InPersonVisitsSingleResponseCaseExample['VisitDetails'],
+    type: VisitDetailValue,
+    isArray: true,
+  })
+  @Type(() => VisitDetailValue)
+  VisitDetails: Array<VisitDetailValue>;
+}
+
+@Exclude()
+@ApiSchema({ name: 'InPersonVisitsNoMultiValueListResponse' })
+export class NestedInPersonVisitsNoMultiValueEntity {
+  @Expose()
+  @ApiProperty({ type: InPersonVisitsEntityNoMultiValue, isArray: true })
+  @Type(() => InPersonVisitsEntityNoMultiValue)
+  items: Array<InPersonVisitsEntityNoMultiValue>;
+
+  constructor(object) {
+    Object.assign(this, object);
+  }
+}
+
+@Exclude()
+@ApiSchema({ name: 'InPersonVisitsMultiValueListResponse' })
+export class NestedInPersonVisitsMultiValueEntity {
+  @Expose()
+  @ApiProperty({ type: InPersonVisitsEntityMultiValue, isArray: true })
+  @Type(() => InPersonVisitsEntityMultiValue)
+  items: Array<InPersonVisitsEntityMultiValue>;
 
   constructor(object) {
     Object.assign(this, object);

--- a/src/entities/in-person-visits.entity.ts
+++ b/src/entities/in-person-visits.entity.ts
@@ -1,8 +1,10 @@
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 import { Exclude, Expose, Transform, Type } from 'class-transformer';
 import {
+  createdByFieldName,
   createdByIdFieldName,
   createdDateFieldName,
+  updatedByFieldName,
   updatedByIdFieldName,
   updatedDateFieldName,
 } from '../common/constants/upstream-constants';
@@ -30,11 +32,15 @@ export const InPersonVisitsSingleResponseCaseExample = {
   ],
   'Parent Id': 'Entity-Id-here',
   'Created By Name': 'Creator-IDIR-Here',
+  [createdByFieldName]: 'Creator-IDIR-Here',
   [createdByIdFieldName]: 'Creator-Id-Here',
   [createdDateFieldName]: '01/01/1970 00:00:00',
+  Created: '01/01/1970 00:00:00',
   'Updated By Name': 'Updater-IDIR-Here',
+  [updatedByFieldName]: 'Updater-IDIR-Here',
   [updatedByIdFieldName]: 'Updater-Id-Here',
   [updatedDateFieldName]: '01/01/1970 00:00:00',
+  Updated: '01/01/1970 00:00:00',
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -152,6 +158,12 @@ class InPersonVisitsEntity {
   'Created By Name': string;
 
   @ApiProperty({
+    example: InPersonVisitsSingleResponseCaseExample[createdByFieldName],
+  })
+  @Expose()
+  [createdByFieldName]: string;
+
+  @ApiProperty({
     example: InPersonVisitsSingleResponseCaseExample[createdByIdFieldName],
   })
   @Expose()
@@ -164,10 +176,22 @@ class InPersonVisitsEntity {
   [createdDateFieldName]: string;
 
   @ApiProperty({
+    example: InPersonVisitsSingleResponseCaseExample['Created'],
+  })
+  @Expose()
+  'Created': string;
+
+  @ApiProperty({
     example: InPersonVisitsSingleResponseCaseExample['Updated By Name'],
   })
   @Expose()
   'Updated By Name': string;
+
+  @ApiProperty({
+    example: InPersonVisitsSingleResponseCaseExample[updatedByFieldName],
+  })
+  @Expose()
+  [updatedByFieldName]: string;
 
   @ApiProperty({
     example: InPersonVisitsSingleResponseCaseExample[updatedByIdFieldName],
@@ -180,6 +204,12 @@ class InPersonVisitsEntity {
   })
   @Expose()
   [updatedDateFieldName]: string;
+
+  @ApiProperty({
+    example: InPersonVisitsSingleResponseCaseExample['Updated'],
+  })
+  @Expose()
+  Updated: string;
 
   constructor(object) {
     Object.assign(this, object);

--- a/src/external-api/request-preparer/request-preparer.service.ts
+++ b/src/external-api/request-preparer/request-preparer.service.ts
@@ -199,6 +199,48 @@ export class RequestPreparerService {
     return response;
   }
 
+  async sendPutRequest(url: string, body, headers, params?) {
+    let response;
+    try {
+      const token =
+        await this.tokenRefresherService.refreshUpstreamBearerToken();
+      if (token === undefined) {
+        throw new Error('Upstream auth failed');
+      }
+      headers['Authorization'] = token;
+      response = await firstValueFrom(
+        this.httpService.put(url, body, { params, headers }),
+      );
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        this.logger.error({
+          msg: error.message,
+          errorDetails: error.response?.data,
+          stack: error.stack,
+          cause: error.cause,
+          buildNumber: this.buildNumber,
+        });
+        if (error.status === 404) {
+          throw new HttpException({}, HttpStatus.NO_CONTENT, { cause: error });
+        }
+      } else {
+        this.logger.error({ error, buildNumber: this.buildNumber });
+      }
+      throw new HttpException(
+        {
+          status: HttpStatus.INTERNAL_SERVER_ERROR,
+          error:
+            error.response?.data !== undefined
+              ? error.response?.data
+              : error.message,
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        { cause: error },
+      );
+    }
+    return response;
+  }
+
   async parallelGetRequest(
     requestSpecs: Array<GetRequestDetails>,
   ): Promise<ParallelResponse> {

--- a/src/helpers/utilities/utilities.service.spec.ts
+++ b/src/helpers/utilities/utilities.service.spec.ts
@@ -15,6 +15,10 @@ import {
   queryHierarchyVisitChildClassName,
   queryHierarchyVisitParentClassName,
 } from '../../common/constants/parameter-constants';
+import {
+  createdByFieldName,
+  updatedByFieldName,
+} from '../../common/constants/upstream-constants';
 
 describe('UtilitiesService', () => {
   let service: UtilitiesService;
@@ -226,7 +230,13 @@ describe('UtilitiesService', () => {
           classExample: InPersonVisitsSingleResponseCaseExample,
           name: queryHierarchyVisitParentClassName,
           searchspec: "([Parent Id]='Id')",
-          exclude: [queryHierarchyVisitChildClassName],
+          exclude: [
+            queryHierarchyVisitChildClassName,
+            createdByFieldName,
+            'Created',
+            updatedByFieldName,
+            'Updated',
+          ],
           childComponents: [
             new QueryHierarchyComponent({
               classExample:

--- a/src/helpers/utilities/utilities.service.ts
+++ b/src/helpers/utilities/utilities.service.ts
@@ -12,6 +12,7 @@ import {
 } from '../../common/constants/error-constants';
 import { emojiRegex } from '../../common/constants/parameter-constants';
 import { IdPathParams } from '../../dto/id-path-params.dto';
+import { QueryHierarchyComponent } from '../../dto/query-hierarchy-component.dto';
 
 @Injectable()
 export class UtilitiesService {
@@ -93,6 +94,33 @@ export class UtilitiesService {
     endpointUrls: object,
   ): string {
     return baseUrl + endpointUrls[type].replace('rowId', id.rowId);
+  }
+
+  constructQueryHierarchy(parentComponent: QueryHierarchyComponent): string {
+    const queryHierarchy = {};
+    const innerObject = this.constructFieldAndSearchSpec(parentComponent);
+    queryHierarchy[parentComponent.name] = innerObject;
+    return JSON.stringify(queryHierarchy);
+  }
+
+  constructFieldAndSearchSpec(component: QueryHierarchyComponent) {
+    let fields = ``;
+    for (const field of Object.keys(component.classExample)) {
+      if (!component.exclude || !component.exclude.includes(field)) {
+        fields = fields + field + ',';
+      }
+    }
+    fields = fields.substring(0, fields.length - 1); // remove trailing comma
+    const innerObject = { fields };
+    if (component.searchspec) {
+      innerObject[`searchspec`] = component.searchspec;
+    }
+    if (component.childComponents) {
+      for (const child of component.childComponents) {
+        innerObject[child.name] = this.constructFieldAndSearchSpec(child);
+      }
+    }
+    return innerObject;
   }
 }
 


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=2f086e5d3321e21084a805570e5c7bdd&sysparm_view=&sysparm_time=1748282657611)

This PR adds multi value support to GET/POST in person visits, fixing a production issue.