### PR TITLE
Feat: Read IDIR from JWT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,7 +62,6 @@ MEMO_RESTRICTED_FIELD='restricted field here'
 EMPLOYEE_WORKSPACE='workspace here'
 EMPLOYEE_ENDPOINT=/endpoint/path/here
 SKIP_AUTH_GUARD=false
-SKIP_JWT_CACHE=false
 
 # Cypress testing only variables. Not required for build
 CYPRESS_BASE_URL=url/including/version/here

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -79,11 +79,6 @@ spec:
                 secretKeyRef:
                     name: visitz-api
                     key: SKIP_AUTH_GUARD
-            - name: SKIP_JWT_CACHE
-              valueFrom:
-                secretKeyRef:
-                    name: visitz-api
-                    key: SKIP_JWT_CACHE
             - name: IN_PERSON_VISITS_ENDPOINT
               valueFrom:
                 secretKeyRef:

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -65,6 +65,10 @@ import {
                   'accept-language': req.raw.headers['accept-language'],
                   'x-credential-identifier':
                     req.raw.headers['x-credential-identifier'],
+                  'x-jti': req.raw.headers['x-jti'],
+                  'x-iss': req.raw.headers['x-iss'],
+                  'x-sub': req.raw.headers['x-sub'],
+                  'x-sid': req.raw.headers['x-sid'],
                   'x-idir-username': req.raw.headers['x-idir-username'],
                   'x-given-name': req.raw.headers['x-given-name'],
                   'x-family-name': req.raw.headers['x-family-name'],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -66,6 +66,13 @@ import {
                   'x-credential-identifier':
                     req.raw.headers['x-credential-identifier'],
                   'x-idir-username': req.raw.headers['x-idir-username'],
+                  'x-given-name': req.raw.headers['x-given-name'],
+                  'x-family-name': req.raw.headers['x-family-name'],
+                  'x-display-name': req.raw.headers['x-display-name'],
+                  'x-full-name':
+                    req.raw.headers['x-given-name'] +
+                    ` ` +
+                    req.raw.headers['x-family-name'],
                   'x-authenticated-groups':
                     req.raw.headers['x-authenticated-groups'],
                   'kong-request-id': req.raw.headers['kong-request-id'],

--- a/src/common/constants/upstream-constants.ts
+++ b/src/common/constants/upstream-constants.ts
@@ -25,6 +25,7 @@ const updatedByFieldName = 'Updated By';
 const updatedByIdFieldName = 'Updated By Id';
 const updatedDateFieldName = 'Updated Date';
 const trustedIdirHeaderName = 'X-ICM-TrustedUsername';
+const idirJWTFieldName = 'idir_username';
 const pageSizeMin = 1;
 const pageSizeMax = 100;
 const pageSizeDefault = 10;
@@ -65,6 +66,7 @@ export {
   updatedByIdFieldName,
   updatedDateFieldName,
   trustedIdirHeaderName,
+  idirJWTFieldName,
   pageSizeMin,
   pageSizeMax,
   pageSizeDefault,

--- a/src/common/guards/auth/auth.service.ts
+++ b/src/common/guards/auth/auth.service.ts
@@ -25,7 +25,6 @@ import { firstValueFrom } from 'rxjs';
 
 @Injectable()
 export class AuthService {
-  skipJWT: boolean;
   cacheTime: number;
   baseUrl: string;
   buildNumber: string;
@@ -45,7 +44,6 @@ export class AuthService {
       this.configService.get<string>('endpointUrls.baseUrl'),
     );
     this.buildNumber = this.configService.get<string>('buildInfo.buildNumber');
-    this.skipJWT = this.configService.get<boolean>('skipJWTCache');
     this.employeeWorkspace = this.configService.get<string>(
       'upstreamAuth.employee.workspace',
     );
@@ -60,7 +58,8 @@ export class AuthService {
   ): Promise<boolean> {
     let idir: string, jti: string, id: string, recordType: RecordType;
     try {
-      idir = req.header(idirUsernameHeaderField).trim();
+      idir = this.utilitiesService.grabIdir(req);
+      req.headers[idirUsernameHeaderField] = idir; // set header to jwt idir for future use
     } catch {
       this.logger.error(`Idir username not found`);
       return false;

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -75,10 +75,6 @@ export default () => ({
     process.env.VPI_APP_ENV === 'prod'
       ? false
       : process.env.SKIP_AUTH_GUARD === 'true',
-  skipJWTCache:
-    process.env.VPI_APP_ENV === 'prod'
-      ? false
-      : process.env.SKIP_JWT_CACHE === 'true',
   endpointUrls: {
     baseUrl: process.env.UPSTREAM_BASE_URL ?? ' ',
     supportNetwork: process.env.SUPPORT_NETWORK_ENDPOINT ?? ' ',

--- a/src/controllers/caseload/caseload.controller.ts
+++ b/src/controllers/caseload/caseload.controller.ts
@@ -95,11 +95,9 @@ export class CaseloadController {
     )
     filter?: AfterQueryParams,
   ): Promise<CaseloadEntity> {
-    await this.externalAuthService.checkEmployeeStatusUpstream(
-      req.headers[idirUsernameHeaderField] as string,
-    ); // auth check
+    await this.externalAuthService.checkEmployeeStatusUpstream(req); // auth check
     return await this.caseloadService.getCaseload(
-      req.headers[idirUsernameHeaderField] as string,
+      req.headers[idirUsernameHeaderField] as string, // this will be set by the jwt in the previous auth check
       req,
       filter,
     );

--- a/src/controllers/external-auth/external-auth.controller.ts
+++ b/src/controllers/external-auth/external-auth.controller.ts
@@ -11,7 +11,6 @@ import { versionInfo } from '../../common/constants/swagger-constants';
 import { ApiForbiddenErrorEntity } from '../../entities/api-forbidden-error.entity';
 import { ApiInternalServerErrorEntity } from '../../entities/api-internal-server-error.entity';
 import { ApiUnauthorizedErrorEntity } from '../../entities/api-unauthorized-error.entity';
-import { idirUsernameHeaderField } from '../../common/constants/upstream-constants';
 import { ExternalAuthService } from './external-auth.service';
 import { Request } from 'express';
 
@@ -33,8 +32,6 @@ export class ExternalAuthController {
     description: 'Empty body. Employee is active.',
   })
   async checkAuthorizationEmployeeStatus(@Req() req: Request): Promise<void> {
-    return await this.externalAuthService.checkEmployeeStatusUpstream(
-      req.headers[idirUsernameHeaderField] as string,
-    );
+    return await this.externalAuthService.checkEmployeeStatusUpstream(req);
   }
 }

--- a/src/controllers/external-auth/external-auth.service.ts
+++ b/src/controllers/external-auth/external-auth.service.ts
@@ -1,10 +1,34 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { Request } from 'express';
 import { AuthService } from '../../common/guards/auth/auth.service';
+import { UtilitiesService } from '../../helpers/utilities/utilities.service';
+import { idirUsernameHeaderField } from '../../common/constants/upstream-constants';
 
 @Injectable()
 export class ExternalAuthService {
-  constructor(private readonly authService: AuthService) {}
-  async checkEmployeeStatusUpstream(idir: string): Promise<void> {
+  private readonly logger = new Logger(AuthService.name);
+
+  constructor(
+    private readonly authService: AuthService,
+    private readonly utilitiesService: UtilitiesService,
+  ) {}
+
+  async checkEmployeeStatusUpstream(req: Request): Promise<void> {
+    let idir = ``;
+    try {
+      idir = this.utilitiesService.grabIdir(req);
+      req.headers[idirUsernameHeaderField] = idir; // set header to jwt idir for future use
+    } catch {
+      this.logger.error(`Idir username not found`);
+      throw new HttpException(
+        {
+          status: HttpStatus.FORBIDDEN,
+          error: 'Forbidden',
+          message: 'Forbidden resource',
+        },
+        HttpStatus.FORBIDDEN,
+      );
+    }
     const status = await this.authService.getEmployeeActiveUpstream(idir);
     if (status === false) {
       throw new HttpException(


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=6b2042f5fb71a2104e3aff907befdcdf&sysparm_view=&sysparm_time=1749153323828)
This PR does the following:

- Change reading of idir from header to jwt.
- Add name logs from request headers.