### PR TITLE
Feat: Add filtering to submission requests

### DIFF
--- a/src/common/constants/error-constants.ts
+++ b/src/common/constants/error-constants.ts
@@ -12,3 +12,6 @@ export const virusScanFailedError = 'Virus scan unavailable.';
 
 export const fileTypeError =
   'File is not one of the allowed file types (jpg, png, pdf).';
+
+export const restrictedNotOpenPostError =
+  'Parent record is restricted on not in "Open" status, cannot submit additional data.';

--- a/src/helpers/attachments/attachments.service.spec.ts
+++ b/src/helpers/attachments/attachments.service.spec.ts
@@ -187,6 +187,14 @@ describe('AttachmentsService', () => {
     ])(
       'should return post values given good input',
       async (data, recordType, body, id, file) => {
+        const checkSpy = jest
+          .spyOn(requestPreparerService, 'sendGetRequest')
+          .mockResolvedValueOnce({
+            data: {},
+            headers: {},
+            status: 200,
+            statusText: 'OK',
+          } as AxiosResponse<any, any>);
         const spy = jest
           .spyOn(requestPreparerService, 'sendPostRequest')
           .mockResolvedValueOnce({
@@ -209,6 +217,7 @@ describe('AttachmentsService', () => {
         );
         expect(spy).toHaveBeenCalledTimes(1);
         expect(virusScanSpy).toHaveBeenCalledTimes(1);
+        expect(checkSpy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new NestedAttachmentsEntity(data));
       },
     );

--- a/src/helpers/attachments/attachments.service.ts
+++ b/src/helpers/attachments/attachments.service.ts
@@ -1,7 +1,9 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import {
   AttachmentParentIdFieldMap,
+  EntityStatus,
   RecordType,
+  RestrictedRecordEnum,
 } from '../../common/constants/enumerations';
 import {
   AttachmentIdPathParams,
@@ -40,6 +42,7 @@ import {
 } from '../../common/constants/upstream-constants';
 import { UtilitiesService } from '../utilities/utilities.service';
 import { VirusScanService } from '../virus-scan/virus-scan.service';
+import { restrictedNotOpenPostError } from '../../common/constants/error-constants';
 
 @Injectable()
 export class AttachmentsService {
@@ -48,6 +51,25 @@ export class AttachmentsService {
   workspace: string | undefined;
   postWorkspace: string | undefined;
   afterFieldName: string | undefined;
+  caseRestrictedFieldName: string;
+  incidentRestrictedFieldName: string;
+  srRestrictedFieldName: string;
+  memoRestrictedFieldName: string;
+  caseStatusFieldName: string;
+  incidentStatusFieldName: string;
+  srStatusFieldName: string;
+  memoStatusFieldName: string;
+  caseWorkspace: string;
+  incidentWorkspace: string;
+  srWorkspace: string;
+  memoWorkspace: string;
+  caseURL: string;
+  incidentURL: string;
+  srURL: string;
+  memoURL: string;
+
+  private readonly logger = new Logger(AttachmentsService.name);
+
   constructor(
     private readonly configService: ConfigService,
     private readonly requestPreparerService: RequestPreparerService,
@@ -65,6 +87,58 @@ export class AttachmentsService {
     this.workspace = this.configService.get('workspaces.attachments');
     this.postWorkspace = this.configService.get('workspaces.postAttachments');
     this.afterFieldName = this.configService.get('afterFieldName.attachments');
+    this.caseRestrictedFieldName = this.configService.get<string>(
+      `upstreamAuth.case.restrictedField`,
+    );
+    this.incidentRestrictedFieldName = this.configService.get<string>(
+      `upstreamAuth.incident.restrictedField`,
+    );
+    this.srRestrictedFieldName = this.configService.get<string>(
+      `upstreamAuth.sr.restrictedField`,
+    );
+    this.memoRestrictedFieldName = this.configService.get<string>(
+      `upstreamAuth.memo.restrictedField`,
+    );
+    this.caseStatusFieldName = this.configService.get<string>(
+      `upstreamAuth.case.statusField`,
+    );
+    this.incidentStatusFieldName = this.configService.get<string>(
+      `upstreamAuth.incident.statusField`,
+    );
+    this.srStatusFieldName = this.configService.get<string>(
+      `upstreamAuth.sr.statusField`,
+    );
+    this.memoStatusFieldName = this.configService.get<string>(
+      `upstreamAuth.memo.statusField`,
+    );
+    this.caseWorkspace = this.configService.get<string>(
+      `upstreamAuth.case.workspace`,
+    );
+    this.incidentWorkspace = this.configService.get<string>(
+      `upstreamAuth.incident.workspace`,
+    );
+    this.srWorkspace = this.configService.get<string>(
+      `upstreamAuth.sr.workspace`,
+    );
+    this.memoWorkspace = this.configService.get<string>(
+      `upstreamAuth.memo.workspace`,
+    );
+    this.caseURL = encodeURI(
+      this.configService.get<string>('endpointUrls.baseUrl') +
+        this.configService.get<string>(`upstreamAuth.case.endpoint`),
+    );
+    this.incidentURL = encodeURI(
+      this.configService.get<string>('endpointUrls.baseUrl') +
+        this.configService.get<string>(`upstreamAuth.incident.endpoint`),
+    );
+    this.srURL = encodeURI(
+      this.configService.get<string>('endpointUrls.baseUrl') +
+        this.configService.get<string>(`upstreamAuth.sr.endpoint`),
+    );
+    this.memoURL = encodeURI(
+      this.configService.get<string>('endpointUrls.baseUrl') +
+        this.configService.get<string>(`upstreamAuth.memo.endpoint`),
+    );
   }
 
   async getSingleAttachmentRecord(
@@ -161,6 +235,7 @@ export class AttachmentsService {
     id: IdPathParams,
     file: Express.Multer.File,
   ): Promise<NestedAttachmentsEntity> {
+    await this.isEligibleForPost(id[idName], idir, type);
     // Scans file before proceeding. This throws an error on infected / unscanable files
     await this.virusScanService.scanFile(file);
     const body = this.prepareAttachmentPostBody(type, dto, id, file);
@@ -183,5 +258,43 @@ export class AttachmentsService {
       params,
     );
     return new NestedAttachmentsEntity(response.data);
+  }
+
+  async isEligibleForPost(
+    parentId: string,
+    idir: string,
+    recordType: RecordType,
+  ): Promise<void> {
+    const recordRestrictedFieldName = `${recordType}RestrictedFieldName`;
+    const recordStatusFieldName = `${recordType}StatusFieldName`;
+    const recordWorkspace = this[`${recordType}Workspace`];
+    const recordURL = this[`${recordType}URL`];
+    const baseSearchSpec =
+      `([Id]="${parentId}" AND ` +
+      `[${this[recordRestrictedFieldName]}]="${RestrictedRecordEnum.False}" ` +
+      `AND [${this[recordStatusFieldName]}]="${EntityStatus.Open}"`;
+    const [headers, params] =
+      this.requestPreparerService.prepareHeadersAndParams(
+        baseSearchSpec,
+        recordWorkspace,
+        undefined,
+        true,
+        idir,
+      );
+    let response;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      response = await this.requestPreparerService.sendGetRequest(
+        recordURL,
+        headers,
+        undefined,
+        params,
+      );
+    } catch {
+      this.logger.error(
+        `Parent ${recordType} record with id '${parentId}' is not open or is restricted`,
+      );
+      throw new BadRequestException([restrictedNotOpenPostError]);
+    }
   }
 }


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=5d8aa320fb9662544e3aff907befdcf4&sysparm_view=&sysparm_time=1750862479889)

This PR adds restricted and non-open entity filtering to all of our submission (POST) requests