### PR TITLE
Fix: Remove time submission from in person visits post

### DIFF
--- a/src/common/constants/upstream-constants.ts
+++ b/src/common/constants/upstream-constants.ts
@@ -7,6 +7,7 @@ const upstreamAttachmentConstraintNull = 'NULL';
 const upstreamVisitConstraintNull = 'NULL';
 const idirUsernameHeaderField = 'x-idir-username';
 const upstreamDateFormat = 'MM/dd/yyyy HH:mm:ss';
+const upstreamDateFormatDateOfVisit = 'MM/dd/yyyy';
 const dummyCreatedDate = '01/01/1970 00:00:00';
 const caseChildServices = 'Child Services';
 const childVisitType = 'In Person Child Youth';
@@ -48,6 +49,7 @@ export {
   upstreamVisitConstraintNull,
   idirUsernameHeaderField,
   upstreamDateFormat,
+  upstreamDateFormatDateOfVisit,
   dummyCreatedDate,
   caseChildServices,
   childVisitType,

--- a/src/dto/post-in-person-visit.dto.spec.ts
+++ b/src/dto/post-in-person-visit.dto.spec.ts
@@ -4,8 +4,8 @@ import { VisitDetails } from '../common/constants/enumerations';
 
 describe('PostInPersonVisitDto transform tests', () => {
   it.each([
-    ['2024-10-24T22:16:24+0000', '10/24/2024 22:16:24'],
-    ['2020-12-31', '12/31/2020 00:00:00'],
+    ['2024-10-24T22:16:24+0000', '10/24/2024'],
+    ['2020-12-31', '12/31/2020'],
   ])(
     `should transform the date when given good, past ISO-8601 input`,
     (date, expected) => {

--- a/src/helpers/utilities/utilities.service.ts
+++ b/src/helpers/utilities/utilities.service.ts
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon';
 import {
   idirJWTFieldName,
   upstreamDateFormat,
+  upstreamDateFormatDateOfVisit,
 } from '../../common/constants/upstream-constants';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
@@ -146,7 +147,7 @@ export function isPastISO8601Date(date: string): string {
     });
     const currentTimeUTC = DateTime.now().toUTC();
     if (dateObject <= currentTimeUTC) {
-      return dateObject.toFormat(upstreamDateFormat);
+      return dateObject.toFormat(upstreamDateFormatDateOfVisit);
     }
   }
   throw new BadRequestException([dateFormatError]);


### PR DESCRIPTION
Send only date and not time in 'Date of visit' field for POST In Person Visits.