### PR TITLE
Feat: Option to omit entities from caseload

### DIFF
--- a/src/common/constants/enumerations.ts
+++ b/src/common/constants/enumerations.ts
@@ -52,6 +52,11 @@ enum ExcludeEmptyFieldsEnum {
   False = 'N',
 }
 
+enum IncludeEntityEnum {
+  True = 'true',
+  False = 'false',
+}
+
 const AttachmentParentIdFieldMap = {
   [RecordType.Case]: casesAttachmentsFieldName,
   [RecordType.Incident]: incidentsAttachmentsFieldName,
@@ -97,6 +102,7 @@ export {
   RecordCountNeededEnum,
   RestrictedRecordEnum,
   ExcludeEmptyFieldsEnum,
+  IncludeEntityEnum,
   AttachmentParentIdFieldMap,
   AttachmentStatusEnum,
   CaseType,

--- a/src/common/constants/error-constants.ts
+++ b/src/common/constants/error-constants.ts
@@ -15,3 +15,6 @@ export const fileTypeError =
 
 export const restrictedNotOpenPostError =
   'Parent record is restricted on not in "Open" status, cannot submit additional data.';
+
+export const caseloadIncludeEntityError =
+  'At least one entity type must be included in a caseload request.';

--- a/src/common/constants/parameter-constants.ts
+++ b/src/common/constants/parameter-constants.ts
@@ -9,6 +9,10 @@ const recordCountHeaderName = 'total-record-count';
 const inlineAttachmentParamName = 'inlineattachment';
 const excludeEmptyFieldsParamName = 'excludeEmptyFieldsInResponse';
 const afterParamName = 'after';
+const caseIncludeParam = 'includeCase';
+const incidentIncludeParam = 'includeIncident';
+const srIncludeParam = 'includeSR';
+const memoIncludeParam = 'includeMemo';
 const queryHierarchyVisitParentClassName = 'ChildVisit';
 const queryHierarchyVisitChildClassName = 'VisitDetails';
 const queryHierarchyEmployeeParentClassName = 'Employee';
@@ -52,6 +56,10 @@ export {
   inlineAttachmentParamName,
   excludeEmptyFieldsParamName,
   afterParamName,
+  caseIncludeParam,
+  incidentIncludeParam,
+  srIncludeParam,
+  memoIncludeParam,
   queryHierarchyVisitParentClassName,
   queryHierarchyVisitChildClassName,
   queryHierarchyEmployeeParentClassName,

--- a/src/controllers/caseload/caseload.controller.spec.ts
+++ b/src/controllers/caseload/caseload.controller.spec.ts
@@ -13,7 +13,7 @@ import {
   CaseloadCompleteResponseExample,
   CaseloadEntity,
 } from '../../entities/caseload.entity';
-import { AfterQueryParams } from '../../dto/filter-query-params.dto';
+import { CaseloadQueryParams } from '../../dto/filter-query-params.dto';
 import { plainToInstance } from 'class-transformer';
 import { getMockReq, getMockRes } from '@jest-mock/express';
 import {
@@ -66,7 +66,7 @@ describe('CaseloadController', () => {
         CaseloadCompleteResponseExample,
         {
           [afterParamName]: '1900-01-01',
-        } as AfterQueryParams,
+        } as CaseloadQueryParams,
       ],
     ])(
       'should return nested values given good input',
@@ -108,7 +108,7 @@ describe('CaseloadController', () => {
         CaseloadCompleteResponseExample,
         {
           [afterParamName]: '1900-01-01',
-        } as AfterQueryParams,
+        } as CaseloadQueryParams,
       ],
     ])(
       'should return nested values given good input',

--- a/src/controllers/caseload/caseload.controller.ts
+++ b/src/controllers/caseload/caseload.controller.ts
@@ -26,7 +26,11 @@ import {
 import {
   CONTENT_TYPE,
   afterParamName,
+  caseIncludeParam,
   excludeEmptyFieldsParamName,
+  incidentIncludeParam,
+  memoIncludeParam,
+  srIncludeParam,
 } from '../../common/constants/parameter-constants';
 import {
   versionInfo,
@@ -38,10 +42,7 @@ import {
   recordCountNeededParamName,
   startRowNumParamName,
 } from '../../common/constants/upstream-constants';
-import {
-  AfterQueryParams,
-  FilterQueryParams,
-} from '../../dto/filter-query-params.dto';
+import { CaseloadQueryParams } from '../../dto/filter-query-params.dto';
 import {
   CaseloadCompleteResponseExample,
   CaseloadEmptyArrayResponseExample,
@@ -78,6 +79,10 @@ export class CaseloadController {
   })
   @ApiQuery({ name: afterParamName, required: false })
   @ApiQuery({ name: excludeEmptyFieldsParamName, required: false })
+  @ApiQuery({ name: caseIncludeParam, required: false })
+  @ApiQuery({ name: incidentIncludeParam, required: false })
+  @ApiQuery({ name: srIncludeParam, required: false })
+  @ApiQuery({ name: memoIncludeParam, required: false })
   @ApiExtraModels(CaseloadEntity)
   @ApiNoContentResponse(noContentResponseSwagger)
   @ApiOkResponse({
@@ -107,7 +112,7 @@ export class CaseloadController {
         skipMissingProperties: true,
       }),
     )
-    filter?: AfterQueryParams,
+    filter?: CaseloadQueryParams,
   ): Promise<CaseloadEntity> {
     await this.externalAuthService.checkEmployeeStatusUpstream(req); // auth check
     return await this.caseloadService.getCaseload(
@@ -127,6 +132,10 @@ export class CaseloadController {
   @ApiQuery({ name: pageSizeParamName, required: false })
   @ApiQuery({ name: startRowNumParamName, required: false })
   @ApiQuery({ name: excludeEmptyFieldsParamName, required: false })
+  @ApiQuery({ name: caseIncludeParam, required: false })
+  @ApiQuery({ name: incidentIncludeParam, required: false })
+  @ApiQuery({ name: srIncludeParam, required: false })
+  @ApiQuery({ name: memoIncludeParam, required: false })
   @ApiExtraModels(OfficeCaseloadEntity)
   @ApiNoContentResponse(noContentResponseSwagger)
   @ApiOkResponse({
@@ -157,7 +166,7 @@ export class CaseloadController {
         skipMissingProperties: true,
       }),
     )
-    filter?: FilterQueryParams,
+    filter?: CaseloadQueryParams,
   ): Promise<OfficeCaseloadEntity> {
     const officeNames =
       await this.externalAuthService.checkEmployeeStatusUpstream(req); // auth check

--- a/src/dto/filter-query-params.dto.ts
+++ b/src/dto/filter-query-params.dto.ts
@@ -11,6 +11,7 @@ import {
 } from 'class-validator';
 import {
   ExcludeEmptyFieldsEnum,
+  IncludeEntityEnum,
   RecordCountNeededEnum,
 } from '../common/constants/enumerations';
 import {
@@ -27,10 +28,14 @@ import {
   inlineAttachmentParamName,
   afterParamName,
   excludeEmptyFieldsParamName,
+  caseIncludeParam,
+  incidentIncludeParam,
+  srIncludeParam,
+  memoIncludeParam,
 } from '../common/constants/parameter-constants';
 
 @Exclude()
-export class AfterQueryParams {
+export class FilterQueryParams {
   @IsOptional()
   @IsISO8601({ strict: true })
   @Expose()
@@ -43,22 +48,6 @@ export class AfterQueryParams {
   })
   [afterParamName]?: string;
 
-  @IsOptional()
-  @IsEnum(ExcludeEmptyFieldsEnum)
-  @Expose()
-  @ApiProperty({
-    example: ExcludeEmptyFieldsEnum.False,
-    default: ExcludeEmptyFieldsEnum.False,
-    enum: ExcludeEmptyFieldsEnum,
-    description:
-      `Whether or not empty fields should be removed from the response. Set to` +
-      ` ${ExcludeEmptyFieldsEnum.True} if you want these fields to be removed.`,
-  })
-  [excludeEmptyFieldsParamName]?: string = ExcludeEmptyFieldsEnum.False;
-}
-
-@Exclude()
-export class FilterQueryParams extends AfterQueryParams {
   @IsOptional()
   @IsEnum(RecordCountNeededEnum)
   @Expose()
@@ -105,6 +94,74 @@ export class FilterQueryParams extends AfterQueryParams {
       ` response header and PageSize parameter to enable pagination.`,
   })
   [startRowNumParamName]?: number;
+
+  @IsOptional()
+  @IsEnum(ExcludeEmptyFieldsEnum)
+  @Expose()
+  @ApiProperty({
+    example: ExcludeEmptyFieldsEnum.False,
+    default: ExcludeEmptyFieldsEnum.False,
+    enum: ExcludeEmptyFieldsEnum,
+    description:
+      `Whether or not empty fields should be removed from the response. Set to` +
+      ` ${ExcludeEmptyFieldsEnum.True} if you want these fields to be removed.`,
+  })
+  [excludeEmptyFieldsParamName]?: string = ExcludeEmptyFieldsEnum.False;
+}
+
+@Exclude()
+export class CaseloadQueryParams extends FilterQueryParams {
+  @IsOptional()
+  @IsEnum(IncludeEntityEnum)
+  @Expose()
+  @ApiProperty({
+    example: IncludeEntityEnum.True,
+    default: IncludeEntityEnum.True,
+    enum: IncludeEntityEnum,
+    description:
+      `Whether or not to include cases in caseload return. Set to` +
+      ` ${IncludeEntityEnum.False} if you wish to exclude cases.`,
+  })
+  [caseIncludeParam]?: string = IncludeEntityEnum.True;
+
+  @IsOptional()
+  @IsEnum(IncludeEntityEnum)
+  @Expose()
+  @ApiProperty({
+    example: IncludeEntityEnum.True,
+    default: IncludeEntityEnum.True,
+    enum: IncludeEntityEnum,
+    description:
+      `Whether or not to include incidents in caseload return. Set to` +
+      ` ${IncludeEntityEnum.False} if you wish to exclude incidents.`,
+  })
+  [incidentIncludeParam]?: string = IncludeEntityEnum.True;
+
+  @IsOptional()
+  @IsEnum(IncludeEntityEnum)
+  @Expose()
+  @ApiProperty({
+    example: IncludeEntityEnum.True,
+    default: IncludeEntityEnum.True,
+    enum: IncludeEntityEnum,
+    description:
+      `Whether or not to include service requests in caseload return. Set to` +
+      ` ${IncludeEntityEnum.False} if you wish to exclude service requests.`,
+  })
+  [srIncludeParam]?: string = IncludeEntityEnum.True;
+
+  @IsOptional()
+  @IsEnum(IncludeEntityEnum)
+  @Expose()
+  @ApiProperty({
+    example: IncludeEntityEnum.True,
+    default: IncludeEntityEnum.True,
+    enum: IncludeEntityEnum,
+    description:
+      `Whether or not to include memos in caseload return. Set to` +
+      ` ${IncludeEntityEnum.False} if you wish to exclude memos.`,
+  })
+  [memoIncludeParam]?: string = IncludeEntityEnum.True;
 }
 
 @Exclude()

--- a/src/dto/get-request-details.dto.ts
+++ b/src/dto/get-request-details.dto.ts
@@ -2,6 +2,7 @@ export class GetRequestDetails {
   url: string;
   headers;
   params?;
+  type?;
 
   constructor(object) {
     Object.assign(this, object);

--- a/src/dto/parallel-response.dto.ts
+++ b/src/dto/parallel-response.dto.ts
@@ -1,6 +1,7 @@
 export class ParallelResponse {
   responses?: Array<any>;
   overallError?: any;
+  orderedTypes?: Array<any>;
 
   constructor(object) {
     Object.assign(this, object);

--- a/src/external-api/request-preparer/request-preparer.service.ts
+++ b/src/external-api/request-preparer/request-preparer.service.ts
@@ -279,6 +279,7 @@ export class RequestPreparerService {
     }
 
     const requestArray: Array<Observable<any>> = [];
+    const typeArray: Array<any> = [];
     for (const req of requestSpecs) {
       requestArray.push(
         this.httpService
@@ -288,6 +289,9 @@ export class RequestPreparerService {
           })
           .pipe(catchError((err) => of(err))),
       );
+      if (req.type) {
+        typeArray.push(req.type);
+      }
     }
     const parallelObservable = forkJoin(requestArray);
     const outputArray = await lastValueFrom(parallelObservable);
@@ -305,6 +309,9 @@ export class RequestPreparerService {
         res.setHeader(recordCountHeaderName, Math.max(...recordCountArray));
       }
     }
-    return new ParallelResponse({ responses: outputArray });
+    return new ParallelResponse({
+      responses: outputArray,
+      orderedTypes: typeArray,
+    });
   }
 }


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=26fc9e5bfbe6e6504e3aff907befdc4a&sysparm_view=&sysparm_time=1752592200727)

This PR allows for the omission of any entity (Case, Incident, SR, Memo) from caseload / office caseload by setting the query parameter include<Entity>=false. Note that if all entities are excluded, an error will be thrown.