### PR TITLE
Feature: Return Siebel status codes by default

### DIFF
--- a/src/common/guards/auth/auth.service.ts
+++ b/src/common/guards/auth/auth.service.ts
@@ -1,6 +1,12 @@
 import { HttpService } from '@nestjs/axios';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Inject,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Cache } from 'cache-manager';
 import { Request } from 'express';
@@ -330,11 +336,35 @@ export class AuthService {
           buildNumber: this.buildNumber,
           function: this.getIsAssignedToOfficeUpstream.name,
         });
+        if (error.status === 404) {
+          throw new HttpException({}, HttpStatus.NO_CONTENT, { cause: error });
+        }
+        throw new HttpException(
+          {
+            status: error.status,
+            error:
+              error.response?.data !== undefined
+                ? error.response?.data
+                : error.message,
+          },
+          error.status,
+          { cause: error },
+        );
       } else {
         this.logger.error({ error, buildNumber: this.buildNumber });
+        throw new HttpException(
+          {
+            status: HttpStatus.INTERNAL_SERVER_ERROR,
+            error:
+              error.response?.data !== undefined
+                ? error.response?.data
+                : error.message,
+          },
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          { cause: error },
+        );
       }
     }
-    return [false, searchspec];
   }
 
   async getEmployeeActiveUpstream(
@@ -395,10 +425,31 @@ export class AuthService {
         });
         await this.cacheManager.set(officeNamesKey, undefined, this.cacheTime);
         await this.cacheManager.set(idir, false, this.cacheTime);
+        throw new HttpException(
+          {
+            status: error.status,
+            error:
+              error.response?.data !== undefined
+                ? error.response?.data
+                : error.message,
+          },
+          error.status,
+          { cause: error },
+        );
       } else {
         this.logger.error({ error, buildNumber: this.buildNumber });
+        throw new HttpException(
+          {
+            status: HttpStatus.INTERNAL_SERVER_ERROR,
+            error:
+              error.response?.data !== undefined
+                ? error.response?.data
+                : error.message,
+          },
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          { cause: error },
+        );
       }
     }
-    return [false, undefined];
   }
 }

--- a/src/external-api/request-preparer/request-preparer.service.ts
+++ b/src/external-api/request-preparer/request-preparer.service.ts
@@ -138,20 +138,31 @@ export class RequestPreparerService {
         if (error.status === 404) {
           throw new HttpException({}, HttpStatus.NO_CONTENT, { cause: error });
         }
+        throw new HttpException(
+          {
+            status: error.status,
+            error:
+              error.response?.data !== undefined
+                ? error.response?.data
+                : error.message,
+          },
+          error.status,
+          { cause: error },
+        );
       } else {
         this.logger.error({ error, buildNumber: this.buildNumber });
+        throw new HttpException(
+          {
+            status: HttpStatus.INTERNAL_SERVER_ERROR,
+            error:
+              error.response?.data !== undefined
+                ? error.response?.data
+                : error.message,
+          },
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          { cause: error },
+        );
       }
-      throw new HttpException(
-        {
-          status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error:
-            error.response?.data !== undefined
-              ? error.response?.data
-              : error.message,
-        },
-        HttpStatus.INTERNAL_SERVER_ERROR,
-        { cause: error },
-      );
     }
     if (
       res !== undefined &&
@@ -189,20 +200,31 @@ export class RequestPreparerService {
         if (error.status === 404) {
           throw new HttpException({}, HttpStatus.NO_CONTENT, { cause: error });
         }
+        throw new HttpException(
+          {
+            status: error.status,
+            error:
+              error.response?.data !== undefined
+                ? error.response?.data
+                : error.message,
+          },
+          error.status,
+          { cause: error },
+        );
       } else {
         this.logger.error({ error, buildNumber: this.buildNumber });
+        throw new HttpException(
+          {
+            status: HttpStatus.INTERNAL_SERVER_ERROR,
+            error:
+              error.response?.data !== undefined
+                ? error.response?.data
+                : error.message,
+          },
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          { cause: error },
+        );
       }
-      throw new HttpException(
-        {
-          status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error:
-            error.response?.data !== undefined
-              ? error.response?.data
-              : error.message,
-        },
-        HttpStatus.INTERNAL_SERVER_ERROR,
-        { cause: error },
-      );
     }
     return response;
   }
@@ -231,20 +253,31 @@ export class RequestPreparerService {
         if (error.status === 404) {
           throw new HttpException({}, HttpStatus.NO_CONTENT, { cause: error });
         }
+        throw new HttpException(
+          {
+            status: error.status,
+            error:
+              error.response?.data !== undefined
+                ? error.response?.data
+                : error.message,
+          },
+          error.status,
+          { cause: error },
+        );
       } else {
         this.logger.error({ error, buildNumber: this.buildNumber });
+        throw new HttpException(
+          {
+            status: HttpStatus.INTERNAL_SERVER_ERROR,
+            error:
+              error.response?.data !== undefined
+                ? error.response?.data
+                : error.message,
+          },
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          { cause: error },
+        );
       }
-      throw new HttpException(
-        {
-          status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error:
-            error.response?.data !== undefined
-              ? error.response?.data
-              : error.message,
-        },
-        HttpStatus.INTERNAL_SERVER_ERROR,
-        { cause: error },
-      );
     }
     return response;
   }


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=5fccf7b4fbf6ee504e3aff907befdc35&sysparm_view=&sysparm_time=1752594385696)

This PR changes auth guard and request preparer to always return siebel status codes (except 404, which changes to 204)