### PR TITLE
Feat: Add build to logs

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,24 +22,27 @@ import {
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({
         pinoHttp: {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          customProps(req, res) {
+            return {
+              buildNumber: configService.get('buildInfo.buildNumber'),
+            };
+          },
           customSuccessObject: (req, res, loggableObject) => {
             return {
               ...loggableObject,
               res,
-              buildNumber: configService.get('buildInfo.buildNumber'),
             };
           },
           customErrorObject: (req, res, loggableObject) => {
             return {
               ...loggableObject,
               res,
-              buildNumber: configService.get('buildInfo.buildNumber'),
             };
           },
           customReceivedObject: (req, res, loggableObject) => {
             return {
               ...loggableObject,
-              buildNumber: configService.get('buildInfo.buildNumber'),
               msg: 'Request received',
             };
           },

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,8 +36,9 @@ async function bootstrap() {
   });
 
   const port = process.env.PORT ?? 3000;
+  const buildNumber = process.env.VPI_APP_LABEL ?? 'localBuild';
   await app.listen(port);
   const logger = new NestJSLogger();
-  logger.log(`API is running on port: ${port}`, { port });
+  logger.log(`API is running on port: ${port}`, { port, buildNumber });
 }
 bootstrap();


### PR DESCRIPTION
This PR adds the build number to (almost) all logs. Note that this doesn't include Nest's built in Routing start up logs as there is no easy way to change those. But all other logs, including service logs, should now have the build number.