### PR TITLE
Feature: Remove Caseload QueryHierarchy

### DIFF
--- a/src/controllers/caseload/caseload.controller.spec.ts
+++ b/src/controllers/caseload/caseload.controller.spec.ts
@@ -86,11 +86,16 @@ describe('CaseloadController', () => {
             ),
           );
 
-        const result = await controller.getCaseload(req, filterQueryParams);
+        const result = await controller.getCaseload(
+          req,
+          res,
+          filterQueryParams,
+        );
         expect(externalAuthServiceSpy).toHaveBeenCalledTimes(1);
         expect(caseloadServiceSpy).toHaveBeenCalledWith(
           'idir',
           req,
+          res,
           filterQueryParams,
         );
         expect(result).toEqual(

--- a/src/controllers/caseload/caseload.controller.ts
+++ b/src/controllers/caseload/caseload.controller.ts
@@ -107,6 +107,7 @@ export class CaseloadController {
   })
   async getCaseload(
     @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
     @Query(
       new ValidationPipe({
         transform: true,
@@ -121,6 +122,7 @@ export class CaseloadController {
     return await this.caseloadService.getCaseload(
       req.headers[idirUsernameHeaderField] as string, // this will be set by the jwt in the previous auth check
       req,
+      res,
       filter,
     );
   }

--- a/src/controllers/caseload/caseload.service.spec.ts
+++ b/src/controllers/caseload/caseload.service.spec.ts
@@ -20,12 +20,6 @@ import {
   uniformResponseParamName,
   VIEW_MODE,
   officeNamesSeparator,
-  queryHierarchyCaseChildClassName,
-  queryHierarchyCaseParentClassName,
-  queryHierarchyIncidentChildAdditionalClassName,
-  queryHierarchyIncidentChildCallClassName,
-  queryHierarchyIncidentChildConcernsClassName,
-  queryHierarchyIncidentParentClassName,
 } from '../../common/constants/parameter-constants';
 import { getMockReq, getMockRes } from '@jest-mock/express';
 import {
@@ -49,18 +43,11 @@ import {
   pageSizeMax,
   trustedIdirHeaderName,
   idirJWTFieldName,
-  queryHierarchyParamName,
 } from '../../common/constants/upstream-constants';
-import { CaseExample, CasePositionExample } from '../../entities/case.entity';
-import {
-  IncidentAdditionalInformationExample,
-  IncidentCallInformationExample,
-  IncidentConcernsExample,
-  IncidentExample,
-} from '../../entities/incident.entity';
+import { CaseExample } from '../../entities/case.entity';
+import { IncidentExample } from '../../entities/incident.entity';
 import { MemoExample } from '../../entities/memo.entity';
 import { SRExample } from '../../entities/sr.entity';
-import { QueryHierarchyComponent } from '../../dto/query-hierarchy-component.dto';
 
 describe('CaseloadService', () => {
   let service: CaseloadService;
@@ -68,7 +55,6 @@ describe('CaseloadService', () => {
   let cacheManager: Cache;
   let requestPreparerService: RequestPreparerService;
   let jwtService: JwtService;
-  let utilitiesService: UtilitiesService;
   const { res, mockClear } = getMockRes();
   const officeNames = `Office Name 1${officeNamesSeparator}Office Name 2`;
 
@@ -95,7 +81,6 @@ describe('CaseloadService', () => {
       RequestPreparerService,
     );
     jwtService = module.get<JwtService>(JwtService);
-    utilitiesService = module.get<UtilitiesService>(UtilitiesService);
 
     configService.set('afterFieldName.cases', 'Last Updated Date');
     configService.set('afterFieldName.incidents', 'Updated Date');
@@ -196,49 +181,11 @@ describe('CaseloadService', () => {
       };
       const caseParams = {
         ...params,
-        [queryHierarchyParamName]: utilitiesService.constructQueryHierarchy(
-          new QueryHierarchyComponent({
-            classExample: CaseExample,
-            name: queryHierarchyCaseParentClassName,
-            searchspec: `(EXISTS ([${caseIdirFieldName}]="${idir}")) AND ([${caseStatusFieldName}]="${EntityStatus.Open}") AND ([${caseRestrictedFieldName}]="${YNEnum.False}") AND ([${caseTypeFieldName}]="${CaseType.ChildServices}" OR [${caseTypeFieldName}]="${CaseType.FamilyServices}" OR [${caseTypeFieldName}]="${CaseType.CYSNFamilyServices}")`,
-            exclude: [queryHierarchyCaseChildClassName],
-            childComponents: [
-              new QueryHierarchyComponent({
-                classExample: CasePositionExample,
-                name: queryHierarchyCaseChildClassName,
-              }),
-            ],
-          }),
-        ),
+        searchspec: `(EXISTS ([${caseIdirFieldName}]="${idir}")) AND ([${caseStatusFieldName}]="${EntityStatus.Open}") AND ([${caseRestrictedFieldName}]="${YNEnum.False}") AND ([${caseTypeFieldName}]="${CaseType.ChildServices}" OR [${caseTypeFieldName}]="${CaseType.FamilyServices}" OR [${caseTypeFieldName}]="${CaseType.CYSNFamilyServices}")`,
       };
       const incidentParams = {
         ...params,
-        [queryHierarchyParamName]: utilitiesService.constructQueryHierarchy(
-          new QueryHierarchyComponent({
-            classExample: IncidentExample,
-            name: queryHierarchyIncidentParentClassName,
-            searchspec: `(EXISTS ([${incidentIdirFieldName}]="${idir}")) AND ([${incidentStatusFieldName}]="${EntityStatus.Open}") AND ([${incidentRestrictedFieldName}]="${YNEnum.False}") AND ([${incidentTypeFieldName}]="${IncidentType.ChildProtection}")`,
-            exclude: [
-              queryHierarchyIncidentChildAdditionalClassName,
-              queryHierarchyIncidentChildCallClassName,
-              queryHierarchyIncidentChildConcernsClassName,
-            ],
-            childComponents: [
-              new QueryHierarchyComponent({
-                classExample: IncidentAdditionalInformationExample,
-                name: queryHierarchyIncidentChildAdditionalClassName,
-              }),
-              new QueryHierarchyComponent({
-                classExample: IncidentCallInformationExample,
-                name: queryHierarchyIncidentChildCallClassName,
-              }),
-              new QueryHierarchyComponent({
-                classExample: IncidentConcernsExample,
-                name: queryHierarchyIncidentChildConcernsClassName,
-              }),
-            ],
-          }),
-        ),
+        searchspec: `(EXISTS ([${incidentIdirFieldName}]="${idir}")) AND ([${incidentStatusFieldName}]="${EntityStatus.Open}") AND ([${incidentRestrictedFieldName}]="${YNEnum.False}") AND ([${incidentTypeFieldName}]="${IncidentType.ChildProtection}")`,
       };
       const srParams = {
         ...params,
@@ -359,49 +306,11 @@ describe('CaseloadService', () => {
       };
       const caseParams = {
         ...params,
-        [queryHierarchyParamName]: utilitiesService.constructQueryHierarchy(
-          new QueryHierarchyComponent({
-            classExample: CaseExample,
-            name: queryHierarchyCaseParentClassName,
-            searchspec: `(([${caseOfficeFieldName}]='Office Name 1' OR [${caseOfficeFieldName}]='Office Name 2') OR EXISTS ([${caseIdirFieldName}]="${idir}")) AND ([${caseStatusFieldName}]="${EntityStatus.Open}") AND ([${caseRestrictedFieldName}]="${YNEnum.False}") AND ([${caseTypeFieldName}]="${CaseType.ChildServices}" OR [${caseTypeFieldName}]="${CaseType.FamilyServices}" OR [${caseTypeFieldName}]="${CaseType.CYSNFamilyServices}")`,
-            exclude: [queryHierarchyCaseChildClassName],
-            childComponents: [
-              new QueryHierarchyComponent({
-                classExample: CasePositionExample,
-                name: queryHierarchyCaseChildClassName,
-              }),
-            ],
-          }),
-        ),
+        searchspec: `(([${caseOfficeFieldName}]='Office Name 1' OR [${caseOfficeFieldName}]='Office Name 2') OR EXISTS ([${caseIdirFieldName}]="${idir}")) AND ([${caseStatusFieldName}]="${EntityStatus.Open}") AND ([${caseRestrictedFieldName}]="${YNEnum.False}") AND ([${caseTypeFieldName}]="${CaseType.ChildServices}" OR [${caseTypeFieldName}]="${CaseType.FamilyServices}" OR [${caseTypeFieldName}]="${CaseType.CYSNFamilyServices}")`,
       };
       const incidentParams = {
         ...params,
-        [queryHierarchyParamName]: utilitiesService.constructQueryHierarchy(
-          new QueryHierarchyComponent({
-            classExample: IncidentExample,
-            name: queryHierarchyIncidentParentClassName,
-            searchspec: `(([${incidentOfficeFieldName}]='Office Name 1' OR [${incidentOfficeFieldName}]='Office Name 2') OR EXISTS ([${incidentIdirFieldName}]="${idir}")) AND ([${incidentStatusFieldName}]="${EntityStatus.Open}") AND ([${incidentRestrictedFieldName}]="${YNEnum.False}") AND ([${incidentTypeFieldName}]="${IncidentType.ChildProtection}")`,
-            exclude: [
-              queryHierarchyIncidentChildAdditionalClassName,
-              queryHierarchyIncidentChildCallClassName,
-              queryHierarchyIncidentChildConcernsClassName,
-            ],
-            childComponents: [
-              new QueryHierarchyComponent({
-                classExample: IncidentAdditionalInformationExample,
-                name: queryHierarchyIncidentChildAdditionalClassName,
-              }),
-              new QueryHierarchyComponent({
-                classExample: IncidentCallInformationExample,
-                name: queryHierarchyIncidentChildCallClassName,
-              }),
-              new QueryHierarchyComponent({
-                classExample: IncidentConcernsExample,
-                name: queryHierarchyIncidentChildConcernsClassName,
-              }),
-            ],
-          }),
-        ),
+        searchspec: `(([${incidentOfficeFieldName}]='Office Name 1' OR [${incidentOfficeFieldName}]='Office Name 2') OR EXISTS ([${incidentIdirFieldName}]="${idir}")) AND ([${incidentStatusFieldName}]="${EntityStatus.Open}") AND ([${incidentRestrictedFieldName}]="${YNEnum.False}") AND ([${incidentTypeFieldName}]="${IncidentType.ChildProtection}")`,
       };
       const srParams = {
         ...params,
@@ -738,7 +647,12 @@ describe('CaseloadService', () => {
             return lookup[headerName];
           }),
         });
-        const result = await service.getCaseload(idir, req, filterQueryParams);
+        const result = await service.getCaseload(
+          idir,
+          req,
+          res,
+          filterQueryParams,
+        );
         const expectedObject = plainToInstance(CaseloadEntity, data, {
           enableImplicitConversion: true,
         });
@@ -758,7 +672,7 @@ describe('CaseloadService', () => {
           });
         const req = getMockReq();
         await expect(
-          service.getCaseload(idir, req, filterQueryParams),
+          service.getCaseload(idir, req, res, filterQueryParams),
         ).rejects.toThrow(error);
       },
     );

--- a/src/controllers/caseload/caseload.service.ts
+++ b/src/controllers/caseload/caseload.service.ts
@@ -23,34 +23,18 @@ import { plainToInstance } from 'class-transformer';
 import {
   pageSizeMax,
   pageSizeParamName,
-  queryHierarchyParamName,
 } from '../../common/constants/upstream-constants';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import { Request, Response } from 'express';
 import {
   caseIncludeParam,
-  excludeEmptyFieldsParamName,
   incidentIncludeParam,
   memoIncludeParam,
   officeNamesSeparator,
-  queryHierarchyCaseChildClassName,
-  queryHierarchyCaseParentClassName,
-  queryHierarchyIncidentChildAdditionalClassName,
-  queryHierarchyIncidentChildCallClassName,
-  queryHierarchyIncidentChildConcernsClassName,
-  queryHierarchyIncidentParentClassName,
   srIncludeParam,
 } from '../../common/constants/parameter-constants';
-import { QueryHierarchyComponent } from '../../dto/query-hierarchy-component.dto';
-import { CaseExample, CasePositionExample } from '../../entities/case.entity';
 import { caseloadIncludeEntityError } from '../../common/constants/error-constants';
-import {
-  IncidentAdditionalInformationExample,
-  IncidentCallInformationExample,
-  IncidentConcernsExample,
-  IncidentExample,
-} from '../../entities/incident.entity';
 
 @Injectable()
 export class CaseloadService {
@@ -212,53 +196,6 @@ export class CaseloadService {
           filter,
         );
       params = this.utilitiesService.recordTypeSearchSpecAppend(params, type);
-      if (type === RecordType.Case) {
-        params[queryHierarchyParamName] =
-          this.utilitiesService.constructQueryHierarchy(
-            new QueryHierarchyComponent({
-              classExample: CaseExample,
-              name: queryHierarchyCaseParentClassName,
-              searchspec: params['searchspec'],
-              exclude: [queryHierarchyCaseChildClassName],
-              childComponents: [
-                new QueryHierarchyComponent({
-                  classExample: CasePositionExample,
-                  name: queryHierarchyCaseChildClassName,
-                }),
-              ],
-            }),
-          );
-        delete params['searchspec'];
-      } else if (type === RecordType.Incident) {
-        params[queryHierarchyParamName] =
-          this.utilitiesService.constructQueryHierarchy(
-            new QueryHierarchyComponent({
-              classExample: IncidentExample,
-              name: queryHierarchyIncidentParentClassName,
-              searchspec: params['searchspec'],
-              exclude: [
-                queryHierarchyIncidentChildAdditionalClassName,
-                queryHierarchyIncidentChildCallClassName,
-                queryHierarchyIncidentChildConcernsClassName,
-              ],
-              childComponents: [
-                new QueryHierarchyComponent({
-                  classExample: IncidentAdditionalInformationExample,
-                  name: queryHierarchyIncidentChildAdditionalClassName,
-                }),
-                new QueryHierarchyComponent({
-                  classExample: IncidentCallInformationExample,
-                  name: queryHierarchyIncidentChildCallClassName,
-                }),
-                new QueryHierarchyComponent({
-                  classExample: IncidentConcernsExample,
-                  name: queryHierarchyIncidentChildConcernsClassName,
-                }),
-              ],
-            }),
-          );
-        delete params['searchspec'];
-      }
       getRequestSpecs.push(
         new GetRequestDetails({
           url: this.baseUrl + this[`${type}Endpoint`],
@@ -309,53 +246,6 @@ export class CaseloadService {
           filter,
         );
       params = this.utilitiesService.recordTypeSearchSpecAppend(params, type);
-      if (type === RecordType.Case) {
-        params[queryHierarchyParamName] =
-          this.utilitiesService.constructQueryHierarchy(
-            new QueryHierarchyComponent({
-              classExample: CaseExample,
-              name: queryHierarchyCaseParentClassName,
-              searchspec: params['searchspec'],
-              exclude: [queryHierarchyCaseChildClassName],
-              childComponents: [
-                new QueryHierarchyComponent({
-                  classExample: CasePositionExample,
-                  name: queryHierarchyCaseChildClassName,
-                }),
-              ],
-            }),
-          );
-        delete params['searchspec'];
-      } else if (type === RecordType.Incident) {
-        params[queryHierarchyParamName] =
-          this.utilitiesService.constructQueryHierarchy(
-            new QueryHierarchyComponent({
-              classExample: IncidentExample,
-              name: queryHierarchyIncidentParentClassName,
-              searchspec: params['searchspec'],
-              exclude: [
-                queryHierarchyIncidentChildAdditionalClassName,
-                queryHierarchyIncidentChildCallClassName,
-                queryHierarchyIncidentChildConcernsClassName,
-              ],
-              childComponents: [
-                new QueryHierarchyComponent({
-                  classExample: IncidentAdditionalInformationExample,
-                  name: queryHierarchyIncidentChildAdditionalClassName,
-                }),
-                new QueryHierarchyComponent({
-                  classExample: IncidentCallInformationExample,
-                  name: queryHierarchyIncidentChildCallClassName,
-                }),
-                new QueryHierarchyComponent({
-                  classExample: IncidentConcernsExample,
-                  name: queryHierarchyIncidentChildConcernsClassName,
-                }),
-              ],
-            }),
-          );
-        delete params['searchspec'];
-      }
       getRequestSpecs.push(
         new GetRequestDetails({
           url: this.baseUrl + this[`${type}Endpoint`],
@@ -558,22 +448,16 @@ export class CaseloadService {
   async getCaseload(
     idir: string,
     req: Request,
+    res: Response,
     filter?: CaseloadQueryParams,
   ): Promise<CaseloadEntity> {
     const entityTypes = this.createEntityTypeArray(filter);
-    const filterObject = {
-      [pageSizeParamName]: pageSizeMax,
-    };
-    if (filter && filter[excludeEmptyFieldsParamName] !== undefined) {
-      filterObject[excludeEmptyFieldsParamName] =
-        filter[excludeEmptyFieldsParamName];
+    if (filter) {
+      filter[pageSizeParamName] = pageSizeMax;
     }
-    const initialFilter = plainToInstance(FilterQueryParams, filterObject, {
-      enableImplicitConversion: true,
-    });
     const getRequestSpecs = this.caseloadUpstreamRequestPreparer(
       idir,
-      initialFilter,
+      filter,
       entityTypes,
     );
     const response = await this.getMapAndFilterCaseload(
@@ -582,6 +466,7 @@ export class CaseloadService {
       req,
       entityTypes,
       filter,
+      res,
     );
     return plainToInstance(CaseloadEntity, response, {
       enableImplicitConversion: true,
@@ -596,6 +481,7 @@ export class CaseloadService {
     filter?: CaseloadQueryParams,
   ) {
     const entityTypes = this.createEntityTypeArray(filter);
+
     const getRequestSpecs = this.officeCaseloadUpstreamRequestPreparer(
       idir,
       filter,


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=0c3b913333cf765084a805570e5c7b2e&sysparm_view=&sysparm_time=1772224193565)

This PR removes Position from Case, and Call/Additional Information from Incident for both GET /caseload and GET /office-caseload.