### PR TITLE
Fix: Attachments blank id field

### DIFF
--- a/src/helpers/attachments/attachments.service.ts
+++ b/src/helpers/attachments/attachments.service.ts
@@ -242,6 +242,7 @@ export class AttachmentsService {
     }
     const upstreamBody = {
       ...dto,
+      Id: '',
       FileExt: file.mimetype.split('/').slice(-1)[0], // grabs last element
       FileName: filename,
       [AttachmentParentIdFieldMap[type]]: id[idName],


### PR DESCRIPTION
Add blank id field to attachments post.