### PR TITLE
Feat: Add POST activities

### DIFF
--- a/src/common/constants/enumerations.ts
+++ b/src/common/constants/enumerations.ts
@@ -425,6 +425,32 @@ const ContactMedicalBehavioralCategoryConditionMap = {
     ContactMedicalBehavioralSkinAndSubcutaneousCondition,
 } as const;
 
+enum ActivityActionBy {
+  Client = 'Client',
+  External = 'External',
+  Health = 'Health',
+  Staff = 'Staff',
+  Supervisor = 'Supervisor',
+  System = 'System',
+}
+
+enum ActivityPriority {
+  Urgent = '1-Urgent',
+  High = '2-High',
+  Standard = '3-Standard',
+}
+
+enum ActivityStatus {
+  Cancelled = 'Cancelled',
+  Closed = 'Closed',
+  IsError = 'Error',
+  InProgress = 'In Progress',
+  Open = 'Open',
+  Pending = 'Pending',
+  Scheduled = 'Scheduled',
+  SetUp = 'Set Up',
+}
+
 export {
   RecordType,
   EntityType,
@@ -461,4 +487,7 @@ export {
   ContactMedicalBehavioralSkinAndSubcutaneousCondition,
   ContactMedicalBehavioralSkinCondition,
   ContactMedicalBehavioralCategoryConditionMap,
+  ActivityActionBy,
+  ActivityPriority,
+  ActivityStatus,
 };

--- a/src/common/constants/error-constants.ts
+++ b/src/common/constants/error-constants.ts
@@ -10,11 +10,17 @@ export const childServicesMedBehavTypeError =
 export const dateFormatError =
   'Date / time must meet the ISO-8601 standard, and cannot be in the future.';
 
+export const dateFormatFutureError =
+  'Date / time must meet the ISO-8601 standard, and cannot be in the past.';
+
 export const dateFormatErrorAnyTime =
   'Date / time must meet the ISO-8601 standard.';
 
 export const dateRangeFormatError =
   'Dates / times must meet the ISO-8601 standard, and end date must be greater than or equal to start date.';
+
+export const endDateFormatError =
+  'Dates / times must meet the ISO-8601 standard, and done date must be greater than or equal to planned date.';
 
 export const upstreamDateFormatError =
   'Date must be valid, not in the future and in the ' +
@@ -43,3 +49,6 @@ export const multiIdError =
 
 export const contactMedicalBehavioralConditionEnumError =
   'Condition must be one of the following values when Category is ${category}: ${enum}';
+
+export const isNotPostiveIntegerStringError =
+  'String must be a positive integer or 0';

--- a/src/common/constants/error-constants.ts
+++ b/src/common/constants/error-constants.ts
@@ -10,7 +10,7 @@ export const childServicesMedBehavTypeError =
 export const dateFormatError =
   'Date / time must meet the ISO-8601 standard, and cannot be in the future.';
 
-export const dateFormatFutureError =
+export const dateFormatPastError =
   'Date / time must meet the ISO-8601 standard, and cannot be in the past.';
 
 export const dateFormatErrorAnyTime =

--- a/src/common/constants/upstream-constants.ts
+++ b/src/common/constants/upstream-constants.ts
@@ -63,6 +63,18 @@ const contactLanguagesCommentsMax = 255;
 const contactMedicalBehavioralCommentsMax = 200;
 const contactMedicalBehavioralDiagnosedByMax = 100;
 const contactMedicalBehavioralTreatmentPlanMax = 100;
+const activityActionCodeMax = 50;
+const activityApptAlarmTimeMax = 16;
+const activityCategoryMax = 30;
+const activityDelayMax = 30;
+const activityDescriptionMax = 250;
+const activityDurationMinutesMax = 16;
+const activityICMSubTypeMax = 30;
+const activityMeetingLocationMax = 1500;
+const activityPlanNameMax = 100;
+const activityResultCodeMax = 50;
+const activitySequenceMax = 255;
+const activityTypeMax = 30;
 
 export {
   baseUrlEnvVarName,
@@ -130,4 +142,16 @@ export {
   contactMedicalBehavioralCommentsMax,
   contactMedicalBehavioralDiagnosedByMax,
   contactMedicalBehavioralTreatmentPlanMax,
+  activityActionCodeMax,
+  activityApptAlarmTimeMax,
+  activityCategoryMax,
+  activityDelayMax,
+  activityDescriptionMax,
+  activityDurationMinutesMax,
+  activityICMSubTypeMax,
+  activityMeetingLocationMax,
+  activityPlanNameMax,
+  activityResultCodeMax,
+  activitySequenceMax,
+  activityTypeMax,
 };

--- a/src/controllers/cases/cases.controller.spec.ts
+++ b/src/controllers/cases/cases.controller.spec.ts
@@ -124,6 +124,7 @@ import {
   NestedActivitiesEntity,
   ActivitiesEntity,
   ActivitiesSingleResponseCaseExample,
+  PostActivitiesResponseCaseExample,
 } from '../../entities/activities.entity';
 
 describe('CasesController', () => {
@@ -1022,6 +1023,42 @@ describe('CasesController', () => {
           res,
         );
         expect(caseServiceSpy).toHaveBeenCalledWith(idPathParams, res, 'idir');
+        expect(result).toEqual(new ActivitiesEntity(data));
+      },
+    );
+  });
+
+  describe('postSingleCaseActivityRecord tests', () => {
+    it.each([
+      [
+        {
+          Status: 'Open',
+          Type: 'type',
+          Description: 'description here',
+          'Action By': 'Staff',
+          Due: '2090-10-05T17:34:57',
+          'Duration Minutes': '60',
+          'Ministry Id': '0-R9NH',
+          Planned: '2090-10-02T17:34:57',
+          Priority: '3-Standard',
+        },
+        { [idName]: 'test' } as IdPathParams,
+        'idir',
+        PostActivitiesResponseCaseExample,
+      ],
+    ])(
+      'should return a single nested given good input',
+      async (body, idPathParams, idir, data) => {
+        const casesServiceSpy = jest
+          .spyOn(casesService, 'postSingleCaseActivityRecord')
+          .mockReturnValueOnce(Promise.resolve(new ActivitiesEntity(data)));
+
+        const result = await controller.postSingleCaseActivityRecord(
+          getMockReq({ headers: { [idirUsernameHeaderField]: idir } }),
+          body,
+          idPathParams,
+        );
+        expect(casesServiceSpy).toHaveBeenCalledWith(body, idir, idPathParams);
         expect(result).toEqual(new ActivitiesEntity(data));
       },
     );

--- a/src/controllers/cases/cases.controller.ts
+++ b/src/controllers/cases/cases.controller.ts
@@ -168,7 +168,9 @@ import {
   ActivitiesListResponseCaseExample,
   ActivitiesEntity,
   ActivitiesSingleResponseCaseExample,
+  PostActivitiesResponseCaseExample,
 } from '../../entities/activities.entity';
+import { PostActivityDto } from '../../dto/post-activity.dto';
 
 @Controller('case')
 @UseGuards(AuthGuard)
@@ -1448,6 +1450,48 @@ export class CasesController {
       id,
       res,
       req.headers[idirUsernameHeaderField] as string,
+    );
+  }
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Post(`:${idName}/activities`)
+  @ApiOperation({
+    description: 'Create an activity record related to the given case id.',
+  })
+  @ApiCreatedResponse({
+    content: {
+      [CONTENT_TYPE]: {
+        examples: {
+          ActivityCreatedResponse: {
+            value: PostActivitiesResponseCaseExample,
+          },
+        },
+      },
+    },
+  })
+  async postSingleCaseActivityRecord(
+    @Req() req: Request,
+    @Body(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        whitelist: true,
+      }),
+    )
+    inPersonVisitDto: PostActivityDto,
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: IdPathParams,
+  ): Promise<ActivitiesEntity> {
+    return await this.casesService.postSingleCaseActivityRecord(
+      inPersonVisitDto,
+      req.headers[idirUsernameHeaderField] as string,
+      id,
     );
   }
 }

--- a/src/controllers/cases/cases.service.spec.ts
+++ b/src/controllers/cases/cases.service.spec.ts
@@ -122,6 +122,7 @@ import {
   NestedActivitiesEntity,
   ActivitiesSingleResponseCaseExample,
   ActivitiesEntity,
+  PostActivitiesResponseCaseExample,
 } from '../../entities/activities.entity';
 
 describe('CasesService', () => {
@@ -1061,6 +1062,42 @@ describe('CasesService', () => {
           res,
           'idir',
         );
+        expect(result).toEqual(new ActivitiesEntity(data));
+      },
+    );
+  });
+
+  describe('postSingleCaseActivityRecord tests', () => {
+    it.each([
+      [
+        {
+          Status: 'Open',
+          Type: 'type',
+          Description: 'description here',
+          'Action By': 'Staff',
+          Due: '2090-10-05T17:34:57',
+          'Duration Minutes': '60',
+          'Ministry Id': '0-R9NH',
+          Planned: '2090-10-02T17:34:57',
+          Priority: '3-Standard',
+        },
+        'idir',
+        { [idName]: 'test' } as IdPathParams,
+        PostActivitiesResponseCaseExample,
+      ],
+    ])(
+      'should return nested values given good input',
+      async (body, idir, idPathParams, data) => {
+        const activitiesSpy = jest
+          .spyOn(activitiesService, 'postSingleActivityRecord')
+          .mockReturnValueOnce(Promise.resolve(new ActivitiesEntity(data)));
+
+        const result = await service.postSingleCaseActivityRecord(
+          body,
+          idir,
+          idPathParams,
+        );
+        expect(activitiesSpy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new ActivitiesEntity(data));
       },
     );

--- a/src/controllers/cases/cases.service.ts
+++ b/src/controllers/cases/cases.service.ts
@@ -97,6 +97,10 @@ import {
   ActivitiesEntity,
   NestedActivitiesEntity,
 } from '../../entities/activities.entity';
+import {
+  PostActivityDto,
+  PostActivityDtoUpstream,
+} from '../../dto/post-activity.dto';
 
 @Injectable()
 export class CasesService {
@@ -505,6 +509,27 @@ export class CasesService {
       res,
       idir,
       filter,
+    );
+  }
+
+  async postSingleCaseActivityRecord(
+    activityDto: PostActivityDto,
+    idir: string,
+    id: IdPathParams,
+  ): Promise<ActivitiesEntity> {
+    const baseObject = {
+      ...activityDto,
+      Id: stringNull,
+      'ICM Type': EntityType.Case,
+      'Case Id': id.rowId,
+      'Primary Owned By': idir,
+    };
+    const body = new PostActivityDtoUpstream(baseObject);
+    return await this.activitiesService.postSingleActivityRecord(
+      RecordType.Case,
+      id,
+      body,
+      idir,
     );
   }
 }

--- a/src/controllers/incidents/incidents.controller.spec.ts
+++ b/src/controllers/incidents/incidents.controller.spec.ts
@@ -146,6 +146,7 @@ import {
   NestedActivitiesEntity,
   ActivitiesSingleResponseIncidentExample,
   ActivitiesEntity,
+  PostActivitiesResponseIncidentExample,
 } from '../../entities/activities.entity';
 
 describe('IncidentsController', () => {
@@ -1272,6 +1273,46 @@ describe('IncidentsController', () => {
           idPathParams,
           res,
           'idir',
+        );
+        expect(result).toEqual(new ActivitiesEntity(data));
+      },
+    );
+  });
+
+  describe('postSingleIncidentActivityRecord tests', () => {
+    it.each([
+      [
+        {
+          Status: 'Open',
+          Type: 'type',
+          Description: 'description here',
+          'Action By': 'Staff',
+          Due: '2090-10-05T17:34:57',
+          'Duration Minutes': '60',
+          'Ministry Id': '0-R9NH',
+          Planned: '2090-10-02T17:34:57',
+          Priority: '3-Standard',
+        },
+        { [idName]: 'test' } as IdPathParams,
+        'idir',
+        PostActivitiesResponseIncidentExample,
+      ],
+    ])(
+      'should return a single nested given good input',
+      async (body, idPathParams, idir, data) => {
+        const incidentsServiceSpy = jest
+          .spyOn(incidentsService, 'postSingleIncidentActivityRecord')
+          .mockReturnValueOnce(Promise.resolve(new ActivitiesEntity(data)));
+
+        const result = await controller.postSingleIncidentActivityRecord(
+          getMockReq({ headers: { [idirUsernameHeaderField]: idir } }),
+          body,
+          idPathParams,
+        );
+        expect(incidentsServiceSpy).toHaveBeenCalledWith(
+          body,
+          idir,
+          idPathParams,
         );
         expect(result).toEqual(new ActivitiesEntity(data));
       },

--- a/src/controllers/incidents/incidents.controller.ts
+++ b/src/controllers/incidents/incidents.controller.ts
@@ -183,7 +183,9 @@ import {
   ActivitiesListResponseIncidentExample,
   ActivitiesEntity,
   ActivitiesSingleResponseIncidentExample,
+  PostActivitiesResponseIncidentExample,
 } from '../../entities/activities.entity';
+import { PostActivityDto } from '../../dto/post-activity.dto';
 
 @Controller('incident')
 @UseGuards(AuthGuard)
@@ -1607,6 +1609,48 @@ export class IncidentsController {
       id,
       res,
       req.headers[idirUsernameHeaderField] as string,
+    );
+  }
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Post(`:${idName}/activities`)
+  @ApiOperation({
+    description: 'Create an activity record related to the given incident id.',
+  })
+  @ApiCreatedResponse({
+    content: {
+      [CONTENT_TYPE]: {
+        examples: {
+          ActivityCreatedResponse: {
+            value: PostActivitiesResponseIncidentExample,
+          },
+        },
+      },
+    },
+  })
+  async postSingleIncidentActivityRecord(
+    @Req() req: Request,
+    @Body(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        whitelist: true,
+      }),
+    )
+    inPersonVisitDto: PostActivityDto,
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: IdPathParams,
+  ): Promise<ActivitiesEntity> {
+    return await this.incidentsService.postSingleIncidentActivityRecord(
+      inPersonVisitDto,
+      req.headers[idirUsernameHeaderField] as string,
+      id,
     );
   }
 }

--- a/src/controllers/incidents/incidents.service.spec.ts
+++ b/src/controllers/incidents/incidents.service.spec.ts
@@ -145,6 +145,7 @@ import {
   NestedActivitiesEntity,
   ActivitiesSingleResponseIncidentExample,
   ActivitiesEntity,
+  PostActivitiesResponseIncidentExample,
 } from '../../entities/activities.entity';
 
 describe('IncidentsService', () => {
@@ -1269,6 +1270,42 @@ describe('IncidentsService', () => {
           res,
           'idir',
         );
+        expect(result).toEqual(new ActivitiesEntity(data));
+      },
+    );
+  });
+
+  describe('postSingleIncidentActivityRecord tests', () => {
+    it.each([
+      [
+        {
+          Status: 'Open',
+          Type: 'type',
+          Description: 'description here',
+          'Action By': 'Staff',
+          Due: '2090-10-05T17:34:57',
+          'Duration Minutes': '60',
+          'Ministry Id': '0-R9NH',
+          Planned: '2090-10-02T17:34:57',
+          Priority: '3-Standard',
+        },
+        'idir',
+        { [idName]: 'test' } as IdPathParams,
+        PostActivitiesResponseIncidentExample,
+      ],
+    ])(
+      'should return nested values given good input',
+      async (body, idir, idPathParams, data) => {
+        const activitiesSpy = jest
+          .spyOn(activitiesService, 'postSingleActivityRecord')
+          .mockReturnValueOnce(Promise.resolve(new ActivitiesEntity(data)));
+
+        const result = await service.postSingleIncidentActivityRecord(
+          body,
+          idir,
+          idPathParams,
+        );
+        expect(activitiesSpy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new ActivitiesEntity(data));
       },
     );

--- a/src/controllers/incidents/incidents.service.ts
+++ b/src/controllers/incidents/incidents.service.ts
@@ -96,6 +96,10 @@ import {
   ActivitiesEntity,
   NestedActivitiesEntity,
 } from '../../entities/activities.entity';
+import {
+  PostActivityDto,
+  PostActivityDtoUpstream,
+} from '../../dto/post-activity.dto';
 
 @Injectable()
 export class IncidentsService {
@@ -529,6 +533,27 @@ export class IncidentsService {
       res,
       idir,
       filter,
+    );
+  }
+
+  async postSingleIncidentActivityRecord(
+    activityDto: PostActivityDto,
+    idir: string,
+    id: IdPathParams,
+  ): Promise<ActivitiesEntity> {
+    const baseObject = {
+      ...activityDto,
+      Id: stringNull,
+      'ICM Type': EntityType.Incident,
+      'Incident Id': id.rowId,
+      'Primary Owned By': idir,
+    };
+    const body = new PostActivityDtoUpstream(baseObject);
+    return await this.activitiesService.postSingleActivityRecord(
+      RecordType.Incident,
+      id,
+      body,
+      idir,
     );
   }
 }

--- a/src/controllers/memos/memos.controller.spec.ts
+++ b/src/controllers/memos/memos.controller.spec.ts
@@ -108,6 +108,7 @@ import {
   NestedActivitiesEntity,
   ActivitiesSingleResponseMemoExample,
   ActivitiesEntity,
+  PostActivitiesResponseMemoExample,
 } from '../../entities/activities.entity';
 
 describe('MemosController', () => {
@@ -851,6 +852,42 @@ describe('MemosController', () => {
           res,
         );
         expect(memoServiceSpy).toHaveBeenCalledWith(idPathParams, res, 'idir');
+        expect(result).toEqual(new ActivitiesEntity(data));
+      },
+    );
+  });
+
+  describe('postSingleMemoActivityRecord tests', () => {
+    it.each([
+      [
+        {
+          Status: 'Open',
+          Type: 'type',
+          Description: 'description here',
+          'Action By': 'Staff',
+          Due: '2090-10-05T17:34:57',
+          'Duration Minutes': '60',
+          'Ministry Id': '0-R9NH',
+          Planned: '2090-10-02T17:34:57',
+          Priority: '3-Standard',
+        },
+        { [idName]: 'test' } as IdPathParams,
+        'idir',
+        PostActivitiesResponseMemoExample,
+      ],
+    ])(
+      'should return a single nested given good input',
+      async (body, idPathParams, idir, data) => {
+        const memosServiceSpy = jest
+          .spyOn(memosService, 'postSingleMemoActivityRecord')
+          .mockReturnValueOnce(Promise.resolve(new ActivitiesEntity(data)));
+
+        const result = await controller.postSingleMemoActivityRecord(
+          getMockReq({ headers: { [idirUsernameHeaderField]: idir } }),
+          body,
+          idPathParams,
+        );
+        expect(memosServiceSpy).toHaveBeenCalledWith(body, idir, idPathParams);
         expect(result).toEqual(new ActivitiesEntity(data));
       },
     );

--- a/src/controllers/memos/memos.controller.ts
+++ b/src/controllers/memos/memos.controller.ts
@@ -148,7 +148,9 @@ import {
   ActivitiesListResponseMemoExample,
   ActivitiesEntity,
   ActivitiesSingleResponseMemoExample,
+  PostActivitiesResponseMemoExample,
 } from '../../entities/activities.entity';
+import { PostActivityDto } from '../../dto/post-activity.dto';
 
 @Controller('memo')
 @UseGuards(AuthGuard)
@@ -1148,6 +1150,48 @@ export class MemosController {
       id,
       res,
       req.headers[idirUsernameHeaderField] as string,
+    );
+  }
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Post(`:${idName}/activities`)
+  @ApiOperation({
+    description: 'Create an activity record related to the given memo id.',
+  })
+  @ApiCreatedResponse({
+    content: {
+      [CONTENT_TYPE]: {
+        examples: {
+          ActivityCreatedResponse: {
+            value: PostActivitiesResponseMemoExample,
+          },
+        },
+      },
+    },
+  })
+  async postSingleMemoActivityRecord(
+    @Req() req: Request,
+    @Body(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        whitelist: true,
+      }),
+    )
+    inPersonVisitDto: PostActivityDto,
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: IdPathParams,
+  ): Promise<ActivitiesEntity> {
+    return await this.memosService.postSingleMemoActivityRecord(
+      inPersonVisitDto,
+      req.headers[idirUsernameHeaderField] as string,
+      id,
     );
   }
 }

--- a/src/controllers/memos/memos.service.spec.ts
+++ b/src/controllers/memos/memos.service.spec.ts
@@ -108,6 +108,7 @@ import {
   NestedActivitiesEntity,
   ActivitiesSingleResponseMemoExample,
   ActivitiesEntity,
+  PostActivitiesResponseMemoExample,
 } from '../../entities/activities.entity';
 
 describe('MemosService', () => {
@@ -890,6 +891,42 @@ describe('MemosService', () => {
           res,
           'idir',
         );
+        expect(result).toEqual(new ActivitiesEntity(data));
+      },
+    );
+  });
+
+  describe('postSingleMemoActivityRecord tests', () => {
+    it.each([
+      [
+        {
+          Status: 'Open',
+          Type: 'type',
+          Description: 'description here',
+          'Action By': 'Staff',
+          Due: '2090-10-05T17:34:57',
+          'Duration Minutes': '60',
+          'Ministry Id': '0-R9NH',
+          Planned: '2090-10-02T17:34:57',
+          Priority: '3-Standard',
+        },
+        'idir',
+        { [idName]: 'test' } as IdPathParams,
+        PostActivitiesResponseMemoExample,
+      ],
+    ])(
+      'should return nested values given good input',
+      async (body, idir, idPathParams, data) => {
+        const activitiesSpy = jest
+          .spyOn(activitiesService, 'postSingleActivityRecord')
+          .mockReturnValueOnce(Promise.resolve(new ActivitiesEntity(data)));
+
+        const result = await service.postSingleMemoActivityRecord(
+          body,
+          idir,
+          idPathParams,
+        );
+        expect(activitiesSpy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new ActivitiesEntity(data));
       },
     );

--- a/src/controllers/memos/memos.service.ts
+++ b/src/controllers/memos/memos.service.ts
@@ -68,6 +68,10 @@ import {
   NestedActivitiesEntity,
 } from '../../entities/activities.entity';
 import { ActivitiesService } from '../../helpers/activities/activities.service';
+import {
+  PostActivityDto,
+  PostActivityDtoUpstream,
+} from '../../dto/post-activity.dto';
 
 @Injectable()
 export class MemosService {
@@ -366,6 +370,27 @@ export class MemosService {
       res,
       idir,
       filter,
+    );
+  }
+
+  async postSingleMemoActivityRecord(
+    activityDto: PostActivityDto,
+    idir: string,
+    id: IdPathParams,
+  ): Promise<ActivitiesEntity> {
+    const baseObject = {
+      ...activityDto,
+      Id: stringNull,
+      'ICM Type': 'Memo',
+      'ICM Memo Id': id.rowId,
+      'Primary Owned By': idir,
+    };
+    const body = new PostActivityDtoUpstream(baseObject);
+    return await this.activitiesService.postSingleActivityRecord(
+      RecordType.Memo,
+      id,
+      body,
+      idir,
     );
   }
 }

--- a/src/controllers/service-requests/service-requests.controller.spec.ts
+++ b/src/controllers/service-requests/service-requests.controller.spec.ts
@@ -128,6 +128,7 @@ import {
   NestedActivitiesEntity,
   ActivitiesSingleResponseSRExample,
   ActivitiesEntity,
+  PostActivitiesResponseSRExample,
 } from '../../entities/activities.entity';
 
 describe('ServiceRequestsController', () => {
@@ -1081,6 +1082,46 @@ describe('ServiceRequestsController', () => {
           idPathParams,
           res,
           'idir',
+        );
+        expect(result).toEqual(new ActivitiesEntity(data));
+      },
+    );
+  });
+
+  describe('postSingleSRActivityRecord tests', () => {
+    it.each([
+      [
+        {
+          Status: 'Open',
+          Type: 'type',
+          Description: 'description here',
+          'Action By': 'Staff',
+          Due: '2090-10-05T17:34:57',
+          'Duration Minutes': '60',
+          'Ministry Id': '0-R9NH',
+          Planned: '2090-10-02T17:34:57',
+          Priority: '3-Standard',
+        },
+        { [idName]: 'test' } as IdPathParams,
+        'idir',
+        PostActivitiesResponseSRExample,
+      ],
+    ])(
+      'should return a single nested given good input',
+      async (body, idPathParams, idir, data) => {
+        const serviceRequestsServiceSpy = jest
+          .spyOn(serviceRequestsService, 'postSingleSRActivityRecord')
+          .mockReturnValueOnce(Promise.resolve(new ActivitiesEntity(data)));
+
+        const result = await controller.postSingleSRActivityRecord(
+          getMockReq({ headers: { [idirUsernameHeaderField]: idir } }),
+          body,
+          idPathParams,
+        );
+        expect(serviceRequestsServiceSpy).toHaveBeenCalledWith(
+          body,
+          idir,
+          idPathParams,
         );
         expect(result).toEqual(new ActivitiesEntity(data));
       },

--- a/src/controllers/service-requests/service-requests.controller.ts
+++ b/src/controllers/service-requests/service-requests.controller.ts
@@ -166,7 +166,9 @@ import {
   ActivitiesListResponseSRExample,
   ActivitiesEntity,
   ActivitiesSingleResponseSRExample,
+  PostActivitiesResponseSRExample,
 } from '../../entities/activities.entity';
+import { PostActivityDto } from '../../dto/post-activity.dto';
 
 @Controller('sr')
 @UseGuards(AuthGuard)
@@ -1398,6 +1400,48 @@ export class ServiceRequestsController {
       id,
       res,
       req.headers[idirUsernameHeaderField] as string,
+    );
+  }
+
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Post(`:${idName}/activities`)
+  @ApiOperation({
+    description: 'Create an activity record related to the given SR id.',
+  })
+  @ApiCreatedResponse({
+    content: {
+      [CONTENT_TYPE]: {
+        examples: {
+          ActivityCreatedResponse: {
+            value: PostActivitiesResponseSRExample,
+          },
+        },
+      },
+    },
+  })
+  async postSingleSRActivityRecord(
+    @Req() req: Request,
+    @Body(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        whitelist: true,
+      }),
+    )
+    inPersonVisitDto: PostActivityDto,
+    @Param(
+      new ValidationPipe({
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+        forbidNonWhitelisted: true,
+      }),
+    )
+    id: IdPathParams,
+  ): Promise<ActivitiesEntity> {
+    return await this.serviceRequestService.postSingleSRActivityRecord(
+      inPersonVisitDto,
+      req.headers[idirUsernameHeaderField] as string,
+      id,
     );
   }
 }

--- a/src/controllers/service-requests/service-requests.service.spec.ts
+++ b/src/controllers/service-requests/service-requests.service.spec.ts
@@ -127,6 +127,7 @@ import {
   NestedActivitiesEntity,
   ActivitiesSingleResponseSRExample,
   ActivitiesEntity,
+  PostActivitiesResponseSRExample,
 } from '../../entities/activities.entity';
 
 describe('ServiceRequestsService', () => {
@@ -1094,6 +1095,42 @@ describe('ServiceRequestsService', () => {
           res,
           'idir',
         );
+        expect(result).toEqual(new ActivitiesEntity(data));
+      },
+    );
+  });
+
+  describe('postSingleSRActivityRecord tests', () => {
+    it.each([
+      [
+        {
+          Status: 'Open',
+          Type: 'type',
+          Description: 'description here',
+          'Action By': 'Staff',
+          Due: '2090-10-05T17:34:57',
+          'Duration Minutes': '60',
+          'Ministry Id': '0-R9NH',
+          Planned: '2090-10-02T17:34:57',
+          Priority: '3-Standard',
+        },
+        'idir',
+        { [idName]: 'test' } as IdPathParams,
+        PostActivitiesResponseSRExample,
+      ],
+    ])(
+      'should return nested values given good input',
+      async (body, idir, idPathParams, data) => {
+        const activitiesSpy = jest
+          .spyOn(activitiesService, 'postSingleActivityRecord')
+          .mockReturnValueOnce(Promise.resolve(new ActivitiesEntity(data)));
+
+        const result = await service.postSingleSRActivityRecord(
+          body,
+          idir,
+          idPathParams,
+        );
+        expect(activitiesSpy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new ActivitiesEntity(data));
       },
     );

--- a/src/controllers/service-requests/service-requests.service.ts
+++ b/src/controllers/service-requests/service-requests.service.ts
@@ -84,6 +84,10 @@ import {
   NestedActivitiesEntity,
 } from '../../entities/activities.entity';
 import { ActivitiesService } from '../../helpers/activities/activities.service';
+import {
+  PostActivityDto,
+  PostActivityDtoUpstream,
+} from '../../dto/post-activity.dto';
 
 @Injectable()
 export class ServiceRequestsService {
@@ -459,6 +463,27 @@ export class ServiceRequestsService {
       res,
       idir,
       filter,
+    );
+  }
+
+  async postSingleSRActivityRecord(
+    activityDto: PostActivityDto,
+    idir: string,
+    id: IdPathParams,
+  ): Promise<ActivitiesEntity> {
+    const baseObject = {
+      ...activityDto,
+      Id: stringNull,
+      'ICM Type': EntityType.SR,
+      'Activity SR Id': id.rowId,
+      'Primary Owned By': idir,
+    };
+    const body = new PostActivityDtoUpstream(baseObject);
+    return await this.activitiesService.postSingleActivityRecord(
+      RecordType.SR,
+      id,
+      body,
+      idir,
     );
   }
 }

--- a/src/dto/post-activity.dto.ts
+++ b/src/dto/post-activity.dto.ts
@@ -1,0 +1,423 @@
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+import { Exclude, Expose, Transform } from 'class-transformer';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsNumberString,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  ValidateIf,
+} from 'class-validator';
+import {
+  ActivityActionBy,
+  ActivityPriority,
+  ActivityStatus,
+  YesNoEnum,
+} from '../common/constants/enumerations';
+import { idRegex } from '../common/constants/parameter-constants';
+import {
+  isCurrentOrFutureISO8601Date,
+  isISO8601DateUpstreamFormatter,
+  isPositiveIntegerString,
+  isValidISO8601EndDate,
+} from '../helpers/utilities/utilities.service';
+import {
+  activityActionCodeMax,
+  activityApptAlarmTimeMax,
+  activityCategoryMax,
+  activityDelayMax,
+  activityDescriptionMax,
+  activityDurationMinutesMax,
+  activityICMSubTypeMax,
+  activityMeetingLocationMax,
+  activityPlanNameMax,
+  activityResultCodeMax,
+  activitySequenceMax,
+  activityTypeMax,
+} from '../common/constants/upstream-constants';
+
+@Exclude()
+@ApiSchema({ name: 'PostActivityRequest' })
+export class PostActivityDto {
+  @IsNotEmpty()
+  @IsEnum(ActivityActionBy)
+  @Expose()
+  @ApiProperty({
+    example: ActivityActionBy.Staff,
+    default: ActivityActionBy.Staff,
+    description: 'Who performed the action.',
+    enum: ActivityActionBy,
+  })
+  'Action By': string = ActivityActionBy.Staff;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(activityActionCodeMax)
+  @Expose()
+  @ApiProperty({
+    example: '',
+    description: 'The action code.',
+    required: false,
+    maxLength: activityActionCodeMax,
+  })
+  'Action Code'?: string;
+
+  @IsOptional()
+  @IsEnum(YesNoEnum)
+  @Expose()
+  @ApiProperty({
+    example: YesNoEnum.True,
+    default: YesNoEnum.True,
+    description: 'If the activity has an alarm.',
+    enum: YesNoEnum,
+  })
+  'Alarm'?: string = YesNoEnum.True;
+
+  @IsOptional()
+  @IsNumberString()
+  @MaxLength(activityApptAlarmTimeMax)
+  @Transform(({ value }) => {
+    if (value != undefined) return isPositiveIntegerString(value);
+    else return value;
+  })
+  @Expose()
+  @ApiProperty({
+    example: '60',
+    description: 'Alarm time in minutes. Must be a positive integer or 0.',
+    maxLength: activityApptAlarmTimeMax,
+    required: false,
+  })
+  'Appt Alarm Time Min'?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(activityCategoryMax)
+  @Expose()
+  @ApiProperty({
+    example: 'General',
+    description: 'The category of activity.',
+    required: false,
+    maxLength: activityCategoryMax,
+  })
+  'Category'?: string;
+
+  @IsOptional()
+  @IsNumberString()
+  @MaxLength(activityDelayMax)
+  @Transform(({ value }) => {
+    if (value != undefined) return isPositiveIntegerString(value);
+    else return value;
+  })
+  @Expose()
+  @ApiProperty({
+    example: '60',
+    description: 'The delay. Must be a positive integer or 0.',
+    maxLength: activityDelayMax,
+    required: false,
+  })
+  'Delay'?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(activityDescriptionMax)
+  @Expose()
+  @ApiProperty({
+    example: 'Description here',
+    description: 'The description of the activity.',
+    required: false,
+    maxLength: activityDescriptionMax,
+  })
+  'Description'?: string;
+
+  @IsOptional()
+  @ValidateIf(
+    (dto) =>
+      typeof dto['Done'] != 'undefined' || typeof dto['Planned'] != 'undefined',
+  )
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  @Transform(({ value, key, obj }) => {
+    return isValidISO8601EndDate(obj['Planned'], value);
+  })
+  @Expose()
+  @ApiProperty({
+    example: '1970-01-01T00:00:00',
+    format: 'date-time',
+    description:
+      'The ISO8601 formatted done date, expected to be provided in UTC. Must be after the planned date.',
+    required: false,
+  })
+  'Done'?: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @Transform(({ value }) => {
+    if (value != undefined) return isCurrentOrFutureISO8601Date(value);
+    else return value;
+  })
+  @Expose()
+  @ApiProperty({
+    example: '1970-01-01T00:00:00',
+    format: 'date-time',
+    description:
+      'The ISO8601 formatted due date, expected to be provided in UTC. Must be equal to or greater than the current datetime.',
+  })
+  'Due': string;
+
+  @IsNotEmpty()
+  @IsNumberString()
+  @MaxLength(activityDurationMinutesMax)
+  @Transform(({ value }) => {
+    if (value != undefined) return isPositiveIntegerString(value);
+    else return value;
+  })
+  @Expose()
+  @ApiProperty({
+    example: '60',
+    default: '0',
+    description:
+      'Activity duration in minutes. Must be a positive integer or 0.',
+    maxLength: activityDurationMinutesMax,
+    required: true,
+  })
+  'Duration Minutes': string = '0';
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(activityICMSubTypeMax)
+  @Expose()
+  @ApiProperty({
+    example: 'Visit',
+    description:
+      'The sub type of activity. This is an enum related to the "Type" parameter, so you may get upstream errors for invalid values.',
+    required: false,
+    maxLength: activityICMSubTypeMax,
+  })
+  'ICM Sub Type'?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(activityMeetingLocationMax)
+  @Expose()
+  @ApiProperty({
+    example: 'Location',
+    description: 'The meeting location.',
+    required: false,
+    maxLength: activityMeetingLocationMax,
+  })
+  'MeetingLocation'?: string;
+
+  @IsNotEmpty()
+  @Matches(idRegex)
+  @Expose()
+  @ApiProperty({
+    example: 'Ministry-Id-Here',
+    description: 'The Id of the ministry for this activity.',
+    required: true,
+  })
+  'Ministry Id': string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(activityPlanNameMax)
+  @Expose()
+  @ApiProperty({
+    example: '',
+    description: 'The plan name.',
+    required: false,
+    maxLength: activityPlanNameMax,
+  })
+  'Plan Name'?: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @Transform(({ value }) => {
+    if (value != undefined) return isISO8601DateUpstreamFormatter(value);
+    else return value;
+  })
+  @Expose()
+  @ApiProperty({
+    example: '1970-01-01T00:00:00',
+    format: 'date-time',
+    description:
+      'The ISO8601 formatted due date, expected to be provided in UTC.',
+  })
+  'Planned': string;
+
+  @IsOptional()
+  @Matches(idRegex)
+  @Expose()
+  @ApiProperty({
+    example: 'Contact-Id-Here',
+    description: 'The Id of the contact you wish to link to the activity.',
+    required: false,
+  })
+  'Primary Contact Id'?: string;
+
+  @IsNotEmpty()
+  @IsEnum(ActivityPriority)
+  @Expose()
+  @ApiProperty({
+    example: ActivityPriority.Standard,
+    default: ActivityPriority.Standard,
+    description: 'The priority of the activity.',
+    enum: ActivityPriority,
+  })
+  'Priority': string = ActivityPriority.Standard;
+
+  @IsOptional()
+  @IsEnum(YesNoEnum)
+  @Expose()
+  @ApiProperty({
+    example: YesNoEnum.False,
+    default: YesNoEnum.False,
+    description: 'If the activity should repeat.',
+    enum: YesNoEnum,
+  })
+  'Repeating'?: string;
+
+  @IsOptional()
+  @IsString()
+  @Transform(({ value }) => {
+    if (value != undefined) return isISO8601DateUpstreamFormatter(value);
+    else return value;
+  })
+  @Expose()
+  @ApiProperty({
+    example: '1970-01-01T00:00:00',
+    format: 'date-time',
+    description:
+      'The ISO8601 formatted expiry date for repeating, expected to be provided in UTC.',
+  })
+  'Repeating Expires'?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(activityResultCodeMax)
+  @Expose()
+  @ApiProperty({
+    example: '',
+    description: 'The result code.',
+    required: false,
+    maxLength: activityResultCodeMax,
+  })
+  'Result Code'?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(activitySequenceMax)
+  @Expose()
+  @ApiProperty({
+    example: '01-01',
+    description: 'The sequence number.',
+    required: false,
+    maxLength: activitySequenceMax,
+  })
+  'Sequence'?: string;
+
+  @IsOptional()
+  @IsEnum(YesNoEnum)
+  @Expose()
+  @ApiProperty({
+    example: YesNoEnum.False,
+    default: YesNoEnum.False,
+    description: 'Whether to show the activity in the contact profile',
+    enum: YesNoEnum,
+    required: false,
+  })
+  'Show In Contact Profile'?: string;
+
+  @IsNotEmpty()
+  @IsEnum(ActivityStatus)
+  @Expose()
+  @ApiProperty({
+    example: ActivityStatus.Open,
+    default: ActivityStatus.Open,
+    description: 'The status of the activity',
+    enum: ActivityStatus,
+  })
+  'Status': string = ActivityStatus.Open;
+
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(activityTypeMax)
+  @Expose()
+  @ApiProperty({
+    example: 'Appointment',
+    description:
+      'The type of activity. This is an enum, so you may get upstream errors for invalid values.',
+    maxLength: activityTypeMax,
+  })
+  'Type': string;
+}
+
+// For use upstream only. Validation not done on parameters here
+// as it should have already been done previously
+export class PostActivityDtoUpstream {
+  'Id': string;
+
+  'Case Id'?: string;
+
+  'Incident Id'?: string;
+
+  'Activity SR Id'?: string;
+
+  'ICM Memo Id'?: string;
+
+  'Action By': ActivityActionBy;
+
+  'Action Code'?: string;
+
+  'Alarm': YesNoEnum;
+
+  'Appt Alarm Time Min'?: string;
+
+  'Category'?: string;
+
+  'Delay'?: string;
+
+  'Description'?: string;
+
+  'Done'?: string;
+
+  'Due': string;
+
+  'Duration Minutes': string;
+
+  'ICM Sub Type'?: string;
+
+  'MeetingLocation'?: string;
+
+  'Ministry Id': string;
+
+  'Plan Name'?: string;
+
+  'Planned': string;
+
+  'Primary Contact Id'?: string;
+
+  'Priority': ActivityPriority;
+
+  'Repeating'?: YesNoEnum;
+
+  'Repeating Expires'?: string;
+
+  'Result Code'?: string;
+
+  'Sequence'?: string;
+
+  'Show In Contact Profile'?: YesNoEnum;
+
+  'Status': ActivityStatus;
+
+  'Type': string;
+
+  'Primary Owned By': string;
+
+  'ICM Type': string;
+
+  constructor(object) {
+    Object.assign(this, object);
+  }
+}

--- a/src/entities/activities.entity.ts
+++ b/src/entities/activities.entity.ts
@@ -186,6 +186,22 @@ export const ActivitiesListResponseMemoExample = {
   ],
 };
 
+export const PostActivitiesResponseCaseExample = {
+  ...ActivitiesSingleResponseCaseExample,
+};
+
+export const PostActivitiesResponseIncidentExample = {
+  ...ActivitiesSingleResponseIncidentExample,
+};
+
+export const PostActivitiesResponseSRExample = {
+  ...ActivitiesSingleResponseSRExample,
+};
+
+export const PostActivitiesResponseMemoExample = {
+  ...ActivitiesSingleResponseMemoExample,
+};
+
 /*
  * Model definitions
  */

--- a/src/helpers/activities/activities.service.spec.ts
+++ b/src/helpers/activities/activities.service.spec.ts
@@ -10,7 +10,7 @@ import { RequestPreparerService } from '../../external-api/request-preparer/requ
 import { TokenRefresherService } from '../../external-api/token-refresher/token-refresher.service';
 import { UtilitiesService } from '../utilities/utilities.service';
 import { AxiosResponse } from 'axios';
-import { RecordType } from '../../common/constants/enumerations';
+import { EntityType, RecordType } from '../../common/constants/enumerations';
 import {
   idName,
   afterParamName,
@@ -27,6 +27,8 @@ import {
   ActivitiesSingleResponseCaseExample,
   ActivitiesEntity,
 } from '../../entities/activities.entity';
+import { stringNull } from '../../common/constants/upstream-constants';
+import { PostActivityDtoUpstream } from '../../dto/post-activity.dto';
 
 describe('ActivitiesService', () => {
   let service: ActivitiesService;
@@ -132,6 +134,53 @@ describe('ActivitiesService', () => {
         );
         expect(spy).toHaveBeenCalledTimes(1);
         expect(result).toEqual(new ActivitiesEntity(data));
+      },
+    );
+  });
+
+  describe('postSingleActivityRecord tests', () => {
+    it.each([
+      [
+        { items: [{ Activities: [{ Id: 'Id Here' }] }] },
+        RecordType.Case,
+        new PostActivityDtoUpstream({
+          Id: stringNull,
+          'ICM Type': EntityType.Case,
+          'Case Id': 'caseid',
+          'Primary Owned By': 'idir',
+          Status: 'Open',
+          Type: 'type',
+          Description: 'description here',
+          'Action By': 'Staff',
+          Due: '2090-10-05T17:34:57',
+          'Duration Minutes': '60',
+          'Ministry Id': '0-R9NH',
+          Planned: '2090-10-02T17:34:57',
+          Priority: '3-Standard',
+        }),
+        { [idName]: 'test' } as IdPathParams,
+      ],
+    ])(
+      'should return post values given good input',
+      async (data, recordType, body, id) => {
+        const spy = jest
+          .spyOn(requestPreparerService, 'sendPutRequest')
+          .mockResolvedValueOnce({
+            data: data,
+            headers: {},
+            status: 200,
+            statusText: 'OK',
+          } as AxiosResponse<any, any>);
+        const result = await service.postSingleActivityRecord(
+          recordType,
+          id,
+          body,
+          'idir',
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(
+          new ActivitiesEntity(data.items[0].Activities[0]),
+        );
       },
     );
   });

--- a/src/helpers/activities/activities.service.ts
+++ b/src/helpers/activities/activities.service.ts
@@ -13,7 +13,14 @@ import {
 } from '../../entities/activities.entity';
 import { RequestPreparerService } from '../../external-api/request-preparer/request-preparer.service';
 import { UtilitiesService } from '../utilities/utilities.service';
-import { activityIdName } from '../../common/constants/parameter-constants';
+import {
+  activityIdName,
+  CONTENT_TYPE,
+  UNIFORM_RESPONSE,
+  uniformResponseParamName,
+} from '../../common/constants/parameter-constants';
+import { trustedIdirHeaderName } from '../../common/constants/upstream-constants';
+import { PostActivityDtoUpstream } from '../../dto/post-activity.dto';
 
 @Injectable()
 export class ActivitiesService {
@@ -116,5 +123,39 @@ export class ActivitiesService {
       filter,
     );
     return new NestedActivitiesEntity(response.data);
+  }
+
+  async postSingleActivityRecord(
+    type: RecordType,
+    id: IdPathParams,
+    body: PostActivityDtoUpstream,
+    idir: string,
+  ): Promise<ActivitiesEntity> {
+    const headers = {
+      Accept: CONTENT_TYPE,
+      'Content-Type': CONTENT_TYPE,
+      'Accept-Encoding': '*',
+      [trustedIdirHeaderName]: idir,
+    };
+    const params = {
+      [uniformResponseParamName]: UNIFORM_RESPONSE,
+    };
+    if (this.workspace !== undefined) {
+      params['workspace'] = this.workspace;
+    }
+
+    const upstreamUrl = this.utilitiesService.constructUpstreamUrl(
+      type,
+      id,
+      this.baseUrl,
+      this.endpointUrls,
+    );
+    const response = await this.requestPreparerService.sendPutRequest(
+      upstreamUrl,
+      body,
+      headers,
+      params,
+    );
+    return new ActivitiesEntity(response.data.items[0].Activities[0]);
   }
 }

--- a/src/helpers/utilities/utilities.service.spec.ts
+++ b/src/helpers/utilities/utilities.service.spec.ts
@@ -7,6 +7,9 @@ import {
   isISO8601DateUpstreamFormatter,
   isValidISO8601StartDateRange,
   isMedicalConditionValidForCategory,
+  isCurrentOrFutureISO8601Date,
+  isValidISO8601EndDate,
+  isPositiveIntegerString,
 } from './utilities.service';
 import { DateTime } from 'luxon';
 import { BadRequestException } from '@nestjs/common';
@@ -188,6 +191,27 @@ describe('UtilitiesService', () => {
     );
   });
 
+  describe('isCurrentOrFutureISO8601Date tests', () => {
+    it.each([[DateTime.now().toUTC().plus(60000).toJSDate().toISOString()]])(
+      `should return a string upon being given a future ISO-8601 date`,
+      (input) => {
+        expect(typeof isCurrentOrFutureISO8601Date(input)).toBe('string');
+      },
+    );
+
+    it.each([
+      [DateTime.now().toUTC().minus(600000).toJSDate().toISOString()],
+      ['abcdefgtlom'],
+    ])(
+      `should throw BadRequestException on past date or unexpected input format`,
+      (input) => {
+        expect(() => {
+          isCurrentOrFutureISO8601Date(input);
+        }).toThrow(BadRequestException);
+      },
+    );
+  });
+
   describe('isISO8601DateUpstreamFormatter tests', () => {
     it.each([[DateTime.now().toUTC().minus(60000).toJSDate().toISOString()]])(
       `should return a string upon being given a ISO-8601 date`,
@@ -243,6 +267,48 @@ describe('UtilitiesService', () => {
       ],
     ])(
       `should throw BadRequestException on invalid range or unexpected input format`,
+      (startDate, endDate) => {
+        expect(() => {
+          isValidISO8601StartDateRange(startDate, endDate);
+        }).toThrow(BadRequestException);
+      },
+    );
+  });
+
+  describe('isValidISO8601EndDate tests', () => {
+    it.each([
+      [
+        DateTime.now().toUTC().minus(60000).toJSDate().toISOString(),
+        DateTime.now().toUTC().toJSDate().toISOString(),
+      ],
+    ])(
+      `should return a string upon being given a valid ISO-8601 end date`,
+      (startDate, endDate) => {
+        expect(typeof isValidISO8601EndDate(startDate, endDate)).toBe('string');
+      },
+    );
+
+    it.each([[undefined, undefined]])(
+      `should return undefined upon being given two undefined values`,
+      (startDate, endDate) => {
+        expect(typeof isValidISO8601EndDate(startDate, endDate)).toBe(
+          'undefined',
+        );
+      },
+    );
+
+    it.each([
+      [
+        DateTime.now().toUTC().toJSDate().toISOString(),
+        DateTime.now().toUTC().minus(600000).toJSDate().toISOString(),
+      ],
+      [undefined, DateTime.now().toUTC().plus(600000).toJSDate().toISOString()],
+      [
+        'abcdefgtlom',
+        DateTime.now().toUTC().plus(600000).toJSDate().toISOString(),
+      ],
+    ])(
+      `should throw BadRequestException on invalid end date or unexpected input format`,
       (startDate, endDate) => {
         expect(() => {
           isValidISO8601StartDateRange(startDate, endDate);
@@ -400,6 +466,24 @@ describe('UtilitiesService', () => {
         const output = service.constructQueryHierarchy(input);
         const outputObject = JSON.parse(output);
         expect(outputObject).toEqual(expected);
+      },
+    );
+  });
+
+  describe('isPositiveIntegerString tests', () => {
+    it.each([['0'], ['20']])(
+      'returns input if string is a postive or zero integer',
+      (input) => {
+        expect(isPositiveIntegerString(input)).toBe(input);
+      },
+    );
+
+    it.each([['-20'], ['20.555'], ['not a number']])(
+      'throws error on non integer or negative number',
+      (input) => {
+        expect(() => {
+          isPositiveIntegerString(input);
+        }).toThrow(BadRequestException);
       },
     );
   });

--- a/src/helpers/utilities/utilities.service.ts
+++ b/src/helpers/utilities/utilities.service.ts
@@ -20,8 +20,11 @@ import {
 import {
   contactMedicalBehavioralConditionEnumError,
   dateFormatError,
+  dateFormatFutureError,
   dateRangeFormatError,
   emojiError,
+  endDateFormatError,
+  isNotPostiveIntegerStringError,
   multiIdError,
   upstreamDateFormatError,
 } from '../../common/constants/error-constants';
@@ -301,6 +304,19 @@ export function isPastISO8601Date(date: string): string {
   throw new BadRequestException([dateFormatError]);
 }
 
+export function isCurrentOrFutureISO8601Date(date: string): string {
+  if (isISO8601(date, { strict: true })) {
+    const dateObject = DateTime.fromISO(date.trim(), {
+      zone: 'UTC',
+    });
+    const currentTimeUTC = DateTime.now().toUTC();
+    if (dateObject >= currentTimeUTC) {
+      return dateObject.toFormat(upstreamDateFormatNoTime);
+    }
+  }
+  throw new BadRequestException([dateFormatFutureError]);
+}
+
 export function isISO8601DateUpstreamFormatter(date: string): string {
   if (isISO8601(date, { strict: true })) {
     const dateObject = DateTime.fromISO(date.trim(), {
@@ -334,6 +350,34 @@ export function isValidISO8601StartDateRange(
     return startDate;
   }
   throw new BadRequestException([dateRangeFormatError]);
+}
+
+export function isValidISO8601EndDate(
+  startDate: string | undefined,
+  endDate: string | undefined,
+): string {
+  if (
+    typeof startDate !== 'undefined' &&
+    isISO8601(startDate, { strict: true })
+  ) {
+    const startDateObject = DateTime.fromISO(startDate.trim(), {
+      zone: 'UTC',
+    });
+    if (typeof endDate == 'undefined') {
+      return endDate;
+    }
+    if (isISO8601(endDate, { strict: true })) {
+      const endDateObject = DateTime.fromISO(endDate.trim(), {
+        zone: 'UTC',
+      });
+      if (endDateObject >= startDateObject) {
+        return endDateObject.toFormat(upstreamDateFormat);
+      }
+    }
+  } else if (typeof startDate == 'undefined' && typeof endDate == 'undefined') {
+    return endDate;
+  }
+  throw new BadRequestException([endDateFormatError]);
 }
 
 export function isValidUpstreamFormatDate(date: string): string {
@@ -390,4 +434,12 @@ export function isIdArray(input): Array<string> {
     }
   }
   throw new BadRequestException([multiIdError]);
+}
+
+export function isPositiveIntegerString(input: string) {
+  const integer = Number.parseFloat(input);
+  if (Number.isNaN(integer) || !Number.isInteger(integer) || integer < 0) {
+    throw new BadRequestException([isNotPostiveIntegerStringError]);
+  }
+  return input;
 }

--- a/src/helpers/utilities/utilities.service.ts
+++ b/src/helpers/utilities/utilities.service.ts
@@ -20,7 +20,7 @@ import {
 import {
   contactMedicalBehavioralConditionEnumError,
   dateFormatError,
-  dateFormatFutureError,
+  dateFormatPastError,
   dateRangeFormatError,
   emojiError,
   endDateFormatError,
@@ -314,7 +314,7 @@ export function isCurrentOrFutureISO8601Date(date: string): string {
       return dateObject.toFormat(upstreamDateFormatNoTime);
     }
   }
-  throw new BadRequestException([dateFormatFutureError]);
+  throw new BadRequestException([dateFormatPastError]);
 }
 
 export function isISO8601DateUpstreamFormatter(date: string): string {


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=ee576dac330fb69484a805570e5c7b76&sysparm_view=&sysparm_time=1780523213517)

This PR adds POST (case|incident|sr|memo)/{rowId}/activities.

Note that Type and ICM Sub Type are enums, but since they are changed often, they are not contained in this repo.